### PR TITLE
add usage trend of the package

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ $ rush docs
 ## 🔗 Related Links
 
 - [Official website](https://visactor.io/vtable)
+- [Usage Trend](https://npm-compare.com/@visactor/vtable)
 
 # 💫 Ecosystem
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -162,6 +162,7 @@ $ rush docs
 # 🔗 相关链接
 
 - [官网](https://visactor.io/vtable)
+- [使用趋势](https://npm-compare.com/@visactor/vtable)
 
 # 💫 生态
 

--- a/packages/vtable/package.json
+++ b/packages/vtable/package.json
@@ -116,5 +116,10 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "homepage": "https://visactor.io/vtable",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/VisActor/VTable.git"
   }
 }


### PR DESCRIPTION
- [x] Site / documentation update


As someone who actively uses @visactor/vtable, I think it would be a great idea to include a link to the npm usage trend for @visactor/vtable. This link would give users helpful information about how the tool is being used, enabling them to make better decisions when selecting a multidimensional data analysis table.

BTW, the missing repo info in package.json was also added.
