### PR TITLE
feat: update interface IEditor and related implementation in VTable

### DIFF
--- a/docs/assets/demo/en/edit/custom-editor.md
+++ b/docs/assets/demo/en/edit/custom-editor.md
@@ -59,9 +59,10 @@ Promise.all([loadCSS(cssUrl), loadJS(jsUrl)])
       this.editorConfig = editorConfig;
     }
 
-    beginEditing(container, referencePosition, value) {
+    onStart({ container, referencePosition, value, endEdit }) {
       const that = this;
       this.container = container;
+      this.successCallback = endEdit;
       const input = document.createElement('input');
 
       input.setAttribute('type', 'text');
@@ -112,20 +113,16 @@ Promise.all([loadCSS(cssUrl), loadJS(jsUrl)])
       return this.element.value;
     }
 
-    exit() {
+    onEnd() {
       this.picker.destroy();
       this.container.removeChild(this.element);
     }
 
-    targetIsOnEditor(target) {
+    onClickElsewhere(target) {
       if (target === this.element || this.picker.el.contains(target)) {
         return true;
       }
       return false;
-    }
-
-    bindSuccessCallback(successCallback) {
-      this.successCallback = successCallback;
     }
   }
   const custom_date_editor = new DateEditor();
@@ -308,5 +305,5 @@ Promise.all([loadCSS(cssUrl), loadJS(jsUrl)])
 })
 .catch((error) => {
     // 处理加载错误
-});  
+});
 ```

--- a/docs/assets/demo/zh/edit/custom-editor.md
+++ b/docs/assets/demo/zh/edit/custom-editor.md
@@ -23,7 +23,7 @@ let  tableInstance;
 // 使用时需要引入插件包@visactor/vtable-editors
 // import * as VTable_editors from '@visactor/vtable-editors';
 // 正常使用方式 const input_editor = new VTable.editors.InputEditor();
-// 官网编辑器中将 VTable.editors重命名成了VTable_editors 
+// 官网编辑器中将 VTable.editors重命名成了VTable_editors
 const input_editor = new VTable_editors.InputEditor();
 VTable.register.editor('input-editor', input_editor);
 const timestamp = new Date().getTime();
@@ -59,9 +59,10 @@ Promise.all([loadCSS(cssUrl), loadJS(jsUrl)])
       this.editorConfig = editorConfig;
     }
 
-    beginEditing(container, referencePosition, value) {
+    onStart({ container, referencePosition, value, endEdit }) {
       const that = this;
       this.container = container;
+      this.successCallback = endEdit;
       const input = document.createElement('input');
 
       input.setAttribute('type', 'text');
@@ -112,20 +113,16 @@ Promise.all([loadCSS(cssUrl), loadJS(jsUrl)])
       return this.element.value;
     }
 
-    exit() {
+    onEnd() {
       this.picker.destroy();
       this.container.removeChild(this.element);
     }
 
-    targetIsOnEditor(target) {
+    onClickElsewhere(target) {
       if (target === this.element || this.picker.el.contains(target)) {
         return true;
       }
       return false;
-    }
-
-    bindSuccessCallback(successCallback) {
-      this.successCallback = successCallback;
     }
   }
   const custom_date_editor = new DateEditor();
@@ -311,5 +308,5 @@ Promise.all([loadCSS(cssUrl), loadJS(jsUrl)])
 })
 .catch((error) => {
     // 处理加载错误
-});  
+});
 ```

--- a/docs/assets/guide/en/edit/edit_cell.md
+++ b/docs/assets/guide/en/edit/edit_cell.md
@@ -157,31 +157,51 @@ VTable.register.editor('custom-date', custom_date_editor);
 ```
 In the above example, we created a custom editor named `DateEditor` and implemented the methods required by the `IEditor` interface. Then, we register the custom editor into the VTable through the `VTable.register.editor` method for use in the table.
 
-`IEditor` interface's definition(github：https://github.com/VisActor/VTable/blob/feat/editCell/packages/vtable-editors/src/types.ts)：
-```
-export interface IEditor {
-  /** 编辑器类型 */
-  editorType?: string;
-  /** 编辑配置 */
-  editorConfig: any;
-  /* 编辑器挂载的容器 由vtable传入 */
+`IEditor` [definition](https://github.com/VisActor/VTable/blob/develop/packages/vtable-editors/src/types.ts)：
+```ts
+export interface IEditor<V = any> {
+  /** Called when cell enters edit mode. */
+  onStart?: (context: EditContext<V>) => void;
+  /** called when cell exits edit mode. */
+  onEnd?: () => void;
+  /**
+   * Called when user click somewhere while editor is in edit mode.
+   *
+   * If returns falsy, VTable will exit edit mode.
+   *
+   * If returns truthy or not defined, nothing will happen.
+   * Which means, in this scenario, you need to call `endEdit` manually
+   * to end edit mode.
+   */
+  onClickElsewhere?: (target: HTMLElement) => boolean;
+  /**
+   * Called when editor mode is exited by any means.
+   * Expected to return the current value of the cell.
+   */
+  getValue: () => V;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface EditContext<V = any> {
+  /** Container element of the VTable instance. */
   container: HTMLElement;
-  /** 编辑完成后调用。注意如果是（enter键，鼠标点击其他位置）这类编辑完成已有VTable实现，编辑器内部有完成按钮等类似的完成操作需要调用这个方法 */
-  successCallback?: Function;
-  /** 获取编辑器当前值 */
-  getValue: () => string | number | null;
-  /** 编辑器进入编辑状态 */
-  beginEditing: (
-    container: HTMLElement,
-    referencePosition: { rect: RectProps; placement?: Placement },
-    value?: string
-  ) => void;
-  /** 编辑器退出编辑状态 */
-  exit: () => void;
-  /** 判断鼠标点击的target是否属于编辑器内部元素 */
-  targetIsOnEditor: (target: HTMLElement) => boolean;
-  /** 由VTable调用来传入编辑成功的回调  请将callback赋值到successCallback */
-  bindSuccessCallback?: (callback: Function) => void;
+  /** Position info of the cell that is being edited. */
+  referencePosition: ReferencePosition;
+  /** Cell value before editing. */
+  value: V;
+  /**
+   * Callback function that can be used to end edit mode.
+   *
+   * In most cases you don't need to call this function,
+   * since Enter key click is handled by VTable automatically,
+   * and mouse click can be handled by `onClickElsewhere`.
+   *
+   * However, if your editor has its own complete button,
+   * or you have external elements like Tooltip,
+   * you may want to use this callback to help you
+   * end edit mode.
+   */
+  endEdit: () => void;
 }
 ```
 
@@ -207,17 +227,20 @@ tableInstance.records;
 
 ## 7. Edit trigger timing
 Editing trigger timing support: double-click a cell to enter editing, click a cell to enter editing, and call the API to manually start editing.
-```
+```ts
+interface ListTableConstructorOptions {
   /** Editing trigger timing Double-click event Click event API manually starts editing. The default is double-click 'doubleclick' */
   editCellTrigger?: 'doubleclick' | 'click' | 'api';
+  // ...
+}
 ```
 
 ## 8. Related APIs
 
-```
+```ts
+interface ListTableAPI {
   /** Set the value of the cell. Note that it corresponds to the original value of the source data, and the vtable instance records will be modified accordingly */
   changeCellValue: (col: number, row: number, value: string | number | null) => void;
-
   /**
    * Batch update data of multiple cells
    * @param col The starting column number of pasted data
@@ -225,15 +248,14 @@ Editing trigger timing support: double-click a cell to enter editing, click a ce
    * @param values Data array of multiple cells
    */
   changeCellValues(startCol: number, startRow: number, values: string[][])
-
   /** Get the editor of cell configuration */
   getEditor: (col: number, row: number) => IEditor;
-
   /** Enable cell editing */
   startEditCell: (col?: number, row?: number) => void;
-
   /** End editing */
   completeEditCell: () => void;
+  // ...
+}
 ```
 
 ## Header Editing

--- a/docs/assets/guide/en/edit/edit_cell.md
+++ b/docs/assets/guide/en/edit/edit_cell.md
@@ -67,7 +67,7 @@ If the several editors provided by the VTable-ediotrs library cannot meet your n
 
 You can use the following flow chart to understand the relationship between the editor and VTable:
 
-![image](https://lf9-dp-fe-cms-tos.byteorg.com/obj/bit-cloud/VTable/guide/editCellProcess.png)
+![image](https://lf9-dp-fe-cms-tos.byteorg.com/obj/bit-cloud/VTable/guide/editCellProcess1.png)
 
 The following is sample code for a custom editor:
 

--- a/docs/assets/guide/zh/edit/edit_cell.md
+++ b/docs/assets/guide/zh/edit/edit_cell.md
@@ -76,7 +76,7 @@ interface ColumnDefine {
 
 可以结合下面这个流程图来理解编辑器和VTable之间的关系：
 
-![image](https://lf9-dp-fe-cms-tos.byteorg.com/obj/bit-cloud/VTable/guide/editCellProcess.png)
+![image](https://lf9-dp-fe-cms-tos.byteorg.com/obj/bit-cloud/VTable/guide/editCellProcess1.png)
 
 以下是一个自定义编辑器的示例代码：
 

--- a/docs/assets/guide/zh/edit/edit_cell.md
+++ b/docs/assets/guide/zh/edit/edit_cell.md
@@ -77,7 +77,7 @@ editor?: string | IEditor | ((args: BaseCellInfo & { table: BaseTableAPI }) => s
 
 以下是一个自定义编辑器的示例代码：
 
-```javascript
+```ts
 class DateEditor implements IEditor {
   editorConfig: any;
   element: HTMLInputElement;
@@ -87,9 +87,10 @@ class DateEditor implements IEditor {
   constructor(editorConfig: any) {
     this.editorConfig = editorConfig;
   }
-  beginEditing(container: HTMLElement, referencePosition: { rect: RectProps; placement?: Placement }, value?: string) {
+  onStart({ container, value, referencePosition, endEdit }: EditContext) {
     const that = this;
     this.container = container;
+    this.successCallback = endEdit
     // const cellValue = luxon.DateTime.fromFormat(value, 'yyyy年MM月dd日').toFormat('yyyy-MM-dd');
     const input = document.createElement('input');
 
@@ -143,18 +144,15 @@ class DateEditor implements IEditor {
   getValue() {
     return this.element.value;
   }
-  exit() {
+  onEnd() {
     this.picker.destroy();
     this.container.removeChild(this.element);
   }
-  targetIsOnEditor(target: HTMLElement) {
+  onClickElsewhere(target: HTMLElement) {
     if (target === this.element || this.picker.el.contains(target)) {
       return true;
     }
     return false;
-  }
-  bindSuccessCallback(successCallback: Function) {
-    this.successCallback = successCallback;
   }
 }
 const custom_date_editor = new DateEditor({});
@@ -231,7 +229,7 @@ tableInstance.records;
    * @param row 粘贴数据的起始行号
    * @param values 多个单元格的数据数组
    */
-  changeCellValues(startCol: number, startRow: number, values: string[][]) 
+  changeCellValues(startCol: number, startRow: number, values: string[][])
 
   /** 获取单元格配置的编辑器 */
   getEditor: (col: number, row: number) => IEditor;

--- a/docs/assets/guide/zh/edit/edit_cell.md
+++ b/docs/assets/guide/zh/edit/edit_cell.md
@@ -65,8 +65,11 @@ columns: [
 
 editor配置可以在columns中，也可以在全局options中定义，同时可以支持自定义函数写法：
 
-```
-editor?: string | IEditor | ((args: BaseCellInfo & { table: BaseTableAPI }) => string | IEditor);
+```ts
+interface ColumnDefine {
+  // ...
+  editor?: string | IEditor | ((args: BaseCellInfo & { table: BaseTableAPI }) => string | IEditor);
+}
 ```
 ## 4. 自定义实现一个编辑器：
 如果VTable-ediotrs库提供的几种编辑器无法满足你的需求，你可以自定义实现一个编辑器。为此，你需要创建一个类，实现编辑器接口(`IEditor`)的要求，并提供必要的方法和逻辑。
@@ -162,31 +165,42 @@ VTable.register.editor('custom-date', custom_date_editor);
 
 在上面的示例中，我们创建了一个名为`DateEditor`的自定义编辑器，并实现了`IEditor`接口所要求的方法。然后，我们通过`VTable.register.editor`方法将自定义编辑器注册到VTable中，以便在表格中使用。
 
-`IEditor`接口具体定义的源码(github：https://github.com/VisActor/VTable/blob/feat/editCell/packages/vtable-editors/src/types.ts)：
-```
-export interface IEditor {
-  /** 编辑器类型 */
-  editorType?: string;
-  /** 编辑配置 */
-  editorConfig: any;
-  /* 编辑器挂载的容器 由vtable传入 */
+`IEditor` 接口[定义](https://github.com/VisActor/VTable/blob/develop/packages/vtable-editors/src/types.ts)：
+```ts
+export interface IEditor<V = any> {
+  /** * 单元格进入编辑状态时调用 */
+  onStart?: (context: EditContext<V>) => void;
+  /** * 单元格退出编辑状态时调用 */
+  onEnd?: () => void;
+  /**
+   * 如果提供了此函数，VTable 将会在用户点击其他地方时调用此函数。
+   * 如果此函数返回了一个假值，VTable 将会调用 `onEnd` 并退出编辑状态。
+   */
+  onClickElsewhere?: (target: HTMLElement) => boolean;
+  /** * 获取编辑器当前值。将在 `onEnd` 调用后调用。 */
+  getValue: () => V;
+  // ...
+}
+
+export interface EditContext<V = any> {
+  /** VTable 实例所处的容器元素 */
   container: HTMLElement;
-  /** 编辑完成后调用。注意如果是（enter键，鼠标点击其他位置）这类编辑完成已有VTable实现，编辑器内部有完成按钮等类似的完成操作需要调用这个方法 */
-  successCallback?: Function;
-  /** 获取编辑器当前值 */
-  getValue: () => string | number | null;
-  /** 编辑器进入编辑状态 */
-  beginEditing: (
-    container: HTMLElement,
-    referencePosition: { rect: RectProps; placement?: Placement },
-    value?: string
-  ) => void;
-  /** 编辑器退出编辑状态 */
-  exit: () => void;
-  /** 判断鼠标点击的target是否属于编辑器内部元素 */
-  targetIsOnEditor: (target: HTMLElement) => boolean;
-  /** 由VTable调用来传入编辑成功的回调  请将callback赋值到successCallback */
-  bindSuccessCallback?: (callback: Function) => void;
+  /** 正在编辑的单元格位置信息 */
+  referencePosition: ReferencePosition;
+  /** 正在进入编辑状态的单元格当前值 */
+  value: V;
+  /**
+   * 用于结束编辑状态的回调。
+   *
+   * 大多数情况下你不需要使用此回调，因为 VTable 已经自带了 Enter 键按下
+   * 来结束编辑状态的行为；而鼠标点击其他位置来结束编辑状态的行为你也
+   * 可以通过 `onClickElsewhere` 函数来获得。
+   *
+   * 然而，如果你有特殊的需求，比如你想在编辑器内部提供一个“完成”按钮，
+   * 或者你有像 Tooltip 这样无法获取到的外部元素，
+   * 这时你可以保存这个回调并在你需要的时候来手动结束编辑状态。
+   */
+  endEdit: () => void;
 }
 ```
 
@@ -212,17 +226,20 @@ tableInstance.records;
 
 ## 7. 编辑触发时机
 编辑触发时机支持：双击单元格进入编辑，单击单元格进入编辑，调用api手动开启编辑.
-```
+```ts
+interface ListTableConstructorOptions {
   /** 编辑触发时机 双击事件  单击事件 api手动开启编辑。默认为双击'doubleclick' */
   editCellTrigger?: 'doubleclick' | 'click' | 'api';
+  // ...
+}
 ```
 
 ## 8. 相关api
 
-```
+```ts
+interface ListTableAPI {
   /** 设置单元格的value值，注意对应的是源数据的原始值，vtable实例records会做对应修改 */
   changeCellValue: (col: number, row: number, value: string | number | null) => void;
-
   /**
    * 批量更新多个单元格的数据
    * @param col 粘贴数据的起始列号
@@ -230,15 +247,14 @@ tableInstance.records;
    * @param values 多个单元格的数据数组
    */
   changeCellValues(startCol: number, startRow: number, values: string[][])
-
   /** 获取单元格配置的编辑器 */
   getEditor: (col: number, row: number) => IEditor;
-
   /** 开启单元格编辑 */
   startEditCell: (col?: number, row?: number) => void;
-
   /** 结束编辑 */
   completeEditCell: () => void;
+  // ...
+}
 ```
 ## 表头编辑
 

--- a/packages/vtable-editors/src/date-input-editor.ts
+++ b/packages/vtable-editors/src/date-input-editor.ts
@@ -7,8 +7,6 @@ export interface DateInputEditorConfig {
 
 export class DateInputEditor extends InputEditor implements IEditor {
   editorType: string = 'DateInput';
-  declare element: HTMLInputElement;
-  successCallback: Function;
   constructor(editorConfig?: DateInputEditorConfig) {
     super(editorConfig);
     this.editorConfig = editorConfig;
@@ -29,8 +27,5 @@ export class DateInputEditor extends InputEditor implements IEditor {
     //   debugger;
     //   this.successCallback();
     // };
-  }
-  bindSuccessCallback(success: Function) {
-    this.successCallback = success;
   }
 }

--- a/packages/vtable-editors/src/input-editor.ts
+++ b/packages/vtable-editors/src/input-editor.ts
@@ -1,4 +1,5 @@
-import type { IEditor, Placement, RectProps } from './types';
+import type { EditContext, IEditor, Placement, RectProps } from './types';
+
 export interface InputEditorConfig {
   max?: number;
   min?: number;
@@ -8,10 +9,13 @@ export class InputEditor implements IEditor {
   editorType: string = 'Input';
   editorConfig: InputEditorConfig;
   container: HTMLElement;
-  declare element: HTMLInputElement;
+  successCallback?: () => void;
+  element?: HTMLInputElement;
+
   constructor(editorConfig?: InputEditorConfig) {
     this.editorConfig = editorConfig;
   }
+
   createElement() {
     const input = document.createElement('input');
     input.setAttribute('type', 'text');
@@ -23,15 +27,19 @@ export class InputEditor implements IEditor {
 
     this.container.appendChild(input);
   }
+
   setValue(value: string) {
     this.element.value = typeof value !== 'undefined' ? value : '';
   }
+
   getValue() {
     return this.element.value;
   }
-  beginEditing(container: HTMLElement, referencePosition: { rect: RectProps; placement?: Placement }, value?: string) {
+
+  onStart({ value, referencePosition, container, endEdit }: EditContext<string>) {
     console.log('input', 'beginEditing---- ');
     this.container = container;
+    this.successCallback = endEdit;
 
     this.createElement();
     if (value) {
@@ -43,24 +51,24 @@ export class InputEditor implements IEditor {
     this.element.focus();
     // do nothing
   }
+
   adjustPosition(rect: RectProps) {
     this.element.style.top = rect.top + 'px';
     this.element.style.left = rect.left + 'px';
     this.element.style.width = rect.width + 'px';
     this.element.style.height = rect.height + 'px';
   }
+
   endEditing() {
     // do nothing
   }
 
-  exit() {
+  onEnd() {
     // do nothing
     this.container.removeChild(this.element);
   }
-  targetIsOnEditor(target: HTMLElement) {
-    if (target === this.element) {
-      return true;
-    }
-    return false;
+
+  onClickElsewhere(target: HTMLElement) {
+    return target === this.element;
   }
 }

--- a/packages/vtable-editors/src/list-editor.ts
+++ b/packages/vtable-editors/src/list-editor.ts
@@ -1,15 +1,15 @@
-import type { IEditor, Placement, RectProps } from './types';
+import type { EditContext, IEditor, Placement, RectProps } from './types';
 export interface ListEditorConfig {
   values: string[];
 }
 
 export class ListEditor implements IEditor {
   editorType: string = 'Input';
-  input: HTMLInputElement;
-  editorConfig: ListEditorConfig;
-  container: HTMLElement;
-  element: HTMLSelectElement;
-  successCallback: Function;
+  input?: HTMLInputElement;
+  editorConfig?: ListEditorConfig;
+  container?: HTMLElement;
+  element?: HTMLSelectElement;
+  successCallback?: () => void;
 
   constructor(editorConfig: ListEditorConfig) {
     console.log('listEditor constructor');
@@ -54,8 +54,9 @@ export class ListEditor implements IEditor {
     return this.element.value;
   }
 
-  beginEditing(container: HTMLElement, referencePosition: { rect: RectProps; placement?: Placement }, value?: string) {
+  onStart({ container, value, referencePosition, endEdit }: EditContext) {
     this.container = container;
+    this.successCallback = endEdit;
 
     this.createElement(value);
 
@@ -79,18 +80,11 @@ export class ListEditor implements IEditor {
     // do nothing
   }
 
-  exit() {
+  onEnd() {
     this.container.removeChild(this.element);
   }
 
-  targetIsOnEditor(target: HTMLElement) {
-    if (target === this.element) {
-      return true;
-    }
-    return false;
-  }
-
-  bindSuccessCallback(success: Function) {
-    this.successCallback = success;
+  onClickElsewhere(target: HTMLElement) {
+    return target === this.element;
   }
 }

--- a/packages/vtable-editors/src/types.ts
+++ b/packages/vtable-editors/src/types.ts
@@ -1,36 +1,93 @@
-export interface IEditor {
-  /** 编辑器类型 */
-  editorType?: string;
-  /** 编辑配置 */
-  editorConfig: any;
-  /* 编辑器挂载的容器 由vtable传入 */
-  container: HTMLElement;
-  /** 编辑完成后调用。注意如果是（enter键，鼠标点击其他位置）这类编辑完成已有VTable实现，编辑器内部有完成按钮等类似的完成操作需要调用这个方法 */
-  successCallback?: Function;
-  /** 获取编辑器当前值 */
-  getValue: () => string | number | null;
-  /** 编辑器进入编辑状态 */
-  beginEditing: (
-    container: HTMLElement,
-    referencePosition: { rect: RectProps; placement?: Placement },
-    value?: string
-  ) => void;
-  /** 编辑器退出编辑状态 */
-  exit: () => void;
-  /** 判断鼠标点击的target是否属于编辑器内部元素 */
-  targetIsOnEditor: (target: HTMLElement) => boolean;
-  /** 由VTable调用来传入编辑成功的回调  请将callback赋值到successCallback */
-  bindSuccessCallback?: (callback: Function) => void;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface IEditor<V = any> {
+  /**
+   * 当单元格进入编辑状态时调用
+   */
+  onStart?: (context: EditContext<V>) => void;
+  /**
+   * 当单元格退出编辑状态时调用
+   */
+  onEnd?: () => void;
+  /**
+   * 当单元格处于编辑状态时鼠标点击其他位置时调用。
+   *
+   * 如果返回值为虚值，则 VTable 将退出编辑状态。
+   *
+   * 如果不提供此函数，VTable 将不会在点击其他位置时自动退出编辑状态。
+   * 你需要使用 `onStart` 提供的 `endEdit` 函数来手动退出编辑状态。
+   */
+  onClickElsewhere?: (target: HTMLElement) => boolean;
+  /**
+   * 当单元格退出编辑状态后，VTable 将调用此函数来获取编辑后的值
+   */
+  getValue: () => V;
+  /**
+   * 编辑器进入编辑状态
+   * @deprecated 请改用 `onStart` 代替。
+   */
+  beginEditing?: (container: HTMLElement, referencePosition: ReferencePosition, value: V) => void;
+  /**
+   * @see onEnd
+   * @deprecated 请改用 `onEnd` 代替。
+   */
+  exit?: () => void;
+  /**
+   * @see onClickElsewhere
+   * @deprecated 请改用 `onClickElsewhere` 代替。
+   */
+  targetIsOnEditor?: (target: HTMLElement) => boolean;
+  /**
+   * beginEditing 调用时调用，提供一个回调函数，用于结束编辑器编辑状态。
+   * @see EditContext#endEdit
+   * @deprecated 请改用 `onStart` 代替。
+   */
+  bindSuccessCallback?: (callback: () => void) => void;
 }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface EditContext<V = any> {
+  /**
+   * VTable 所在容器
+   */
+  container: HTMLElement;
+  /**
+   * 单元格所在位置
+   */
+  referencePosition: ReferencePosition;
+  /**
+   * 单元格当前值
+   */
+  value: V;
+  /**
+   * 立即结束编辑器编辑状态。
+   *
+   * 大多数情况下你并不需要调用这个函数，因为
+   * VTable 已经自动对 Enter 键以及
+   * 鼠标点击其他位置（`onClickElsewhere`）进行了处理。
+   *
+   * 但如果你的编辑器内部有自己的完成按钮，或是
+   * 像 Tooltip 有外部悬浮元素，不太好或者没有办法
+   * 使用 `onClickElsewhere` 进行判断时，你
+   * 可以使用这个回调来帮助你处理编辑器的退出逻辑。
+   */
+  endEdit: () => void;
+}
+
 export interface RectProps {
   left: number;
   top: number;
   width: number;
   height: number;
 }
+
 export enum Placement {
   top = 'top',
   bottom = 'bottom',
   left = 'left',
   right = 'right'
+}
+
+export interface ReferencePosition {
+  rect: RectProps;
+  placement?: Placement;
 }

--- a/packages/vtable-editors/src/types.ts
+++ b/packages/vtable-editors/src/types.ts
@@ -1,74 +1,77 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface IEditor<V = any> {
   /**
-   * 当单元格进入编辑状态时调用
+   * Called when cell enters edit mode.
+   *
+   * Warning will be thrown if you don't provide this function
+   * after removal of `beginEditing`.
    */
   onStart?: (context: EditContext<V>) => void;
   /**
-   * 当单元格退出编辑状态时调用
+   * called when cell exits edit mode.
+   *
+   * Warning will be thrown if you don't provide this function
+   * after removal of `exit`.
    */
   onEnd?: () => void;
   /**
-   * 当单元格处于编辑状态时鼠标点击其他位置时调用。
+   * Called when user click somewhere while editor is in edit mode.
    *
-   * 如果返回值为虚值，则 VTable 将退出编辑状态。
+   * If returns falsy, VTable will exit edit mode.
    *
-   * 如果不提供此函数，VTable 将不会在点击其他位置时自动退出编辑状态。
-   * 你需要使用 `onStart` 提供的 `endEdit` 函数来手动退出编辑状态。
+   * If returns truthy or not defined, nothing will happen.
+   * Which means, in this scenario, you need to call `endEdit` manually
+   * to end edit mode.
    */
   onClickElsewhere?: (target: HTMLElement) => boolean;
   /**
-   * 当单元格退出编辑状态后，VTable 将调用此函数来获取编辑后的值
+   * Called when editor mode is exited by any means.
+   * Expected to return the current value of the cell.
    */
   getValue: () => V;
   /**
-   * 编辑器进入编辑状态
-   * @deprecated 请改用 `onStart` 代替。
+   * Called when cell enter edit mode.
+   * @deprecated use `onStart` instead.
    */
   beginEditing?: (container: HTMLElement, referencePosition: ReferencePosition, value: V) => void;
   /**
    * @see onEnd
-   * @deprecated 请改用 `onEnd` 代替。
+   * @deprecated use `onEnd` instead.
    */
   exit?: () => void;
   /**
    * @see onClickElsewhere
-   * @deprecated 请改用 `onClickElsewhere` 代替。
+   * @deprecated use `onClickElsewhere` instead.
    */
   targetIsOnEditor?: (target: HTMLElement) => boolean;
   /**
-   * beginEditing 调用时调用，提供一个回调函数，用于结束编辑器编辑状态。
+   * Called when cell enters edit mode with a callback function
+   * that can be used to end edit mode.
    * @see EditContext#endEdit
-   * @deprecated 请改用 `onStart` 代替。
+   * @deprecated callback is provided as `endEdit` in `EditContext`, use `onStart` instead.
    */
   bindSuccessCallback?: (callback: () => void) => void;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface EditContext<V = any> {
-  /**
-   * VTable 所在容器
-   */
+  /** Container element of the VTable instance. */
   container: HTMLElement;
-  /**
-   * 单元格所在位置
-   */
+  /** Position info of the cell that is being edited. */
   referencePosition: ReferencePosition;
-  /**
-   * 单元格当前值
-   */
+  /** Cell value before editing. */
   value: V;
   /**
-   * 立即结束编辑器编辑状态。
+   * Callback function that can be used to end edit mode.
    *
-   * 大多数情况下你并不需要调用这个函数，因为
-   * VTable 已经自动对 Enter 键以及
-   * 鼠标点击其他位置（`onClickElsewhere`）进行了处理。
+   * In most cases you don't need to call this function,
+   * since Enter key click is handled by VTable automatically,
+   * and mouse click can be handled by `onClickElsewhere`.
    *
-   * 但如果你的编辑器内部有自己的完成按钮，或是
-   * 像 Tooltip 有外部悬浮元素，不太好或者没有办法
-   * 使用 `onClickElsewhere` 进行判断时，你
-   * 可以使用这个回调来帮助你处理编辑器的退出逻辑。
+   * However, if your editor has its own complete button,
+   * or you have external elements like Tooltip,
+   * you may want to use this callback to help you
+   * end edit mode.
    */
   endEdit: () => void;
 }

--- a/packages/vtable/examples/editor/custom-date-editor.ts
+++ b/packages/vtable/examples/editor/custom-date-editor.ts
@@ -1,5 +1,5 @@
 import * as VTable from '../../src';
-import type { IEditor, RectProps, Placement } from '@visactor/vtable-editors';
+import type { IEditor, RectProps, Placement, EditContext } from '@visactor/vtable-editors';
 import { DateInputEditor, InputEditor, ListEditor } from '@visactor/vtable-editors';
 import * as luxon from 'luxon';
 import * as Pikaday from 'pikaday';
@@ -21,9 +21,10 @@ class DateEditor implements IEditor {
   constructor(editorConfig: any) {
     this.editorConfig = editorConfig;
   }
-  beginEditing(container: HTMLElement, referencePosition: { rect: RectProps; placement?: Placement }, value?: string) {
+  onStart({ container, value, referencePosition, endEdit }: EditContext) {
     const that = this;
     this.container = container;
+    this.successCallback = endEdit;
     // const cellValue = luxon.DateTime.fromFormat(value, 'yyyy年MM月dd日').toFormat('yyyy-MM-dd');
     const input = document.createElement('input');
 
@@ -79,18 +80,15 @@ class DateEditor implements IEditor {
     // const cellValue = luxon.DateTime.fromFormat(this.element.value, 'yyyy-MM-dd').toFormat('yyyy年MM月dd日');
     return this.element.value;
   }
-  exit() {
+  onEnd() {
     this.picker.destroy();
     this.container.removeChild(this.element);
   }
-  targetIsOnEditor(target: HTMLElement) {
+  onClickElsewhere(target: HTMLElement) {
     if (target === this.element || this.picker.el.contains(target)) {
       return true;
     }
     return false;
-  }
-  bindSuccessCallback(successCallback: Function) {
-    this.successCallback = successCallback;
   }
 }
 const custom_date_editor = new DateEditor({});

--- a/packages/vtable/src/edit/edit-manager.ts
+++ b/packages/vtable/src/edit/edit-manager.ts
@@ -103,12 +103,14 @@ export class EditManeger {
 
     const target = e?.target as HTMLElement | undefined;
 
-    if (target && this.editingEditor.targetIsOnEditor?.(target)) {
-      // TODO: 添加开发时弃用警告
-      return;
+    if (this.editingEditor.targetIsOnEditor) {
+      if (target && this.editingEditor.targetIsOnEditor(target)) {
+        // TODO: 添加开发时弃用警告
+        return;
+      }
     }
 
-    if (target && this.editingEditor.onClickElsewhere?.(target)) {
+    if (!this.editingEditor.onClickElsewhere || (target && this.editingEditor.onClickElsewhere?.(target))) {
       return;
     }
 

--- a/packages/vtable/src/edit/edit-manager.ts
+++ b/packages/vtable/src/edit/edit-manager.ts
@@ -77,10 +77,12 @@ export class EditManeger {
       const rect = this.table.getCellRangeRelativeRect(this.table.getCellRange(col, row));
       const referencePosition = { rect: { left: rect.left, top: rect.top, width: rect.width, height: rect.height } };
 
-      // TODO: 添加开发时弃用警告
+      editor.beginEditing && console.warn('VTable Warn: `beginEditing` is deprecated, please use `onStart` instead.');
       editor.beginEditing?.(this.table.getElement(), referencePosition, dataValue);
 
-      // TODO: 添加开发时弃用警告
+      if (editor.bindSuccessCallback) {
+        console.warn('VTable Warn: `bindSuccessCallback` is deprecated, please use `onStart` instead.');
+      }
       editor.bindSuccessCallback?.(() => {
         this.completeEdit();
       });
@@ -104,8 +106,8 @@ export class EditManeger {
     const target = e?.target as HTMLElement | undefined;
 
     if (this.editingEditor.targetIsOnEditor) {
+      console.warn('VTable Warn: `targetIsOnEditor` is deprecated, please use `onClickElsewhere` instead.');
       if (target && this.editingEditor.targetIsOnEditor(target)) {
-        // TODO: 添加开发时弃用警告
         return;
       }
     }
@@ -114,11 +116,13 @@ export class EditManeger {
       return;
     }
 
-    // TODO: 开发时检查 getValue 是否为方法，如不是则提供警告
+    if (!this.editingEditor.getValue) {
+      console.warn('VTable Warn: `getValue` is not provided, did you forget to implement it?');
+    }
     const changedValue = this.editingEditor.getValue?.();
     (this.table as ListTableAPI).changeCellValue(this.editCell.col, this.editCell.row, changedValue);
 
-    // TODO: 添加开发时弃用警告
+    this.editingEditor.exit && console.warn('VTable Warn: `exit` is deprecated, please use `onEnd` instead.');
     this.editingEditor.exit?.();
     this.editingEditor.onEnd?.();
     this.editingEditor = null;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->
close #1005.

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

As described in #1005, the current `IEditor` definition is ambiguous.

This PR brings more consistent naming and correspond implementations.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

Added `onStart`, `onEnd`, `onClickElsewhere` on `IEditor` and implemented in VTable.

Deprecated `beginEditing`, `exit`, `targetIsOnEditor` and `bindSuccessCallback`.

Migration guide:
- `beginEditing` -> `onStart`
> All original params are provided in the first param of `onStart` as `EditContext` described.
- `exit` -> `onEnd`
- `targetIsOnEditor` -> `onClickElsewhere`
- `bindSuccessCallback` -> `onStart`
> The original callback provided as first param of  `bindSuccessCallback` is now provided as `endEdit` in first param of `onStart`.

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
