### PR TITLE
fix:  RESIZE_COLUMN_END event was not sent when double-clicking the e…

### DIFF
--- a/packages/vtable/src/event/event.ts
+++ b/packages/vtable/src/event/event.ts
@@ -150,6 +150,15 @@ export class EventManager {
               state.columnResize.isRightFrozen
             );
           }
+          const colWidths = [];
+          // 返回所有列宽信息
+          for (let col = 0; col < this.table.colCount; col++) {
+            colWidths.push(this.table.getColWidth(col));
+          }
+          this.table.fireListeners(TABLE_EVENT_TYPE.RESIZE_COLUMN_END, {
+            col: resizeCol.col,
+            colWidths
+          });
         }
       }
     });


### PR DESCRIPTION

### 🤔 This is a ...

- [x] Bug fix

### 💡 Background and solution
**background**: 
Double-click the column. When the column width changes, the RESIZE_COLUMN_END event is not triggered. Therefore, the latest column width cannot be obtained externally

**solution**
After the DBLCLICK_CELL event is complete, obtain the latest column width from table, and finally send the RESIZE_COLUMN_END event

