### PR TITLE
fix: fix defalultQueryMethod in vtable-search #1448

### DIFF
--- a/common/changes/@visactor/vtable/fix-search-query-method_2024-04-11-11-45.json
+++ b/common/changes/@visactor/vtable/fix-search-query-method_2024-04-11-11-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@visactor/vtable",
+      "comment": "fix: fix defalultQueryMethod in vtable-search #1448",
+      "type": "none"
+    }
+  ],
+  "packageName": "@visactor/vtable"
+}

--- a/packages/vtable-search/src/search-component/search-component.ts
+++ b/packages/vtable-search/src/search-component/search-component.ts
@@ -1,4 +1,5 @@
 import type * as VTable from '@visactor/vtable';
+import { isValid } from '@visactor/vutils';
 
 type IVTable = VTable.ListTable | VTable.PivotTable | VTable.PivotChart;
 
@@ -30,7 +31,7 @@ const defalutFocusHightlightCellStyle: Partial<VTable.TYPES.CellStyle> = {
 };
 
 function defalultQueryMethod(queryStr: string, value: string) {
-  return value.toString().includes(queryStr);
+  return isValid(queryStr) && isValid(value) && value.toString().includes(queryStr);
 }
 
 export class SearchComponent {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/VTable/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
