### PR TITLE
fix: 修复 updateOption 函数修改 customCellStyle 后，使用 vtable-search 报错的问题

### DIFF
--- a/packages/vtable/src/core/BaseTable.ts
+++ b/packages/vtable/src/core/BaseTable.ts
@@ -2154,8 +2154,8 @@ export abstract class BaseTable extends EventTarget implements BaseTableAPI {
     this.clearCellStyleCache();
     this.clearColWidthCache();
     this.clearRowHeightCache();
-    this.customCellStylePlugin = new CustomCellStylePlugin(
-      this,
+
+    this.customCellStylePlugin.updateCustomCell(
       options.customCellStyle ?? [],
       options.customCellStyleArrangement ?? []
     );

--- a/packages/vtable/src/plugins/custom-cell-style.ts
+++ b/packages/vtable/src/plugins/custom-cell-style.ts
@@ -131,6 +131,15 @@ export class CustomCellStylePlugin {
     }
     this.table.scenegraph.updateNextFrame();
   }
+
+  updateCustomCell(customCellStyle: CustomCellStyle[], customCellStyleArrangement: CustomCellStyleArrangement[]) {
+    customCellStyle.forEach((cellStyle: CustomCellStyle) => {
+      this.registerCustomCellStyle(cellStyle.id, cellStyle.style);
+    });
+    customCellStyleArrangement.forEach((cellStyle: CustomCellStyleArrangement) => {
+      this.arrangeCustomCellStyle(cellStyle.cellPosition, cellStyle.customStyleId);
+    });
+  }
 }
 
 export function mergeStyle(cacheStyle: Style, customCellStyle: ColumnStyleOption): Style {


### PR DESCRIPTION
<!--
首先，感谢您参与代码贡献! 😄
为了提交新的功能或修改,请在主分支`main`分支上拉取开发分支 。
在提交PR 之前，请确认下面列到的一些内容
你的PR在核心成员review后，合并到主分支
谢谢！
-->

### 🤔 这个分支是...

- [ ] 新功能
- [x] Bug fix
- [ ] Ts 类型更新
- [ ] 打包优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 重构
- [ ] 依赖版本更新
- [ ] 代码优化
- [ ] 测试 case 更新
- [ ] 分支合并
- [ ] 网站/文档更新
- [ ] demo 更新
- [ ] Workflow
- [ ] 配置修改
- [ ] 发布
- [ ] 其他 (具体是什么，请补充?)

### 🔗 相关 issue 连接

<!--
1. 相关的issue或者讨论，请贴在这里.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 问题的背景&解决方案

<!--
1. 描述问题和场景
2. 如果包含UI/交互相关的修改，请提供GIF或者截图
3. 提供如何解决问题的，如果是开发新的功能，请提供最终的API实现和使用案例
-->

https://github.com/VisActor/VTable/pull/1447 修复了通过 updateOption 函数更新 customCellStyle 不生效的问题。
处理方式是重新 new CustomCellStylePlugin。
这种方式会导致 vtable-search 绑定的__search_component_highlight  __search_component_focuse 失效，搜索时会报错

![img_v3_029s_de81bd26-49b5-4a94-a965-267bd1869e9g](https://github.com/VisActor/VTable/assets/16183057/10792261-e3fa-441c-8c2b-cde79e6db1ab)


### 📝 Changelog

<!--
描述用户侧的修改，并列出所有可能的新功能、修改、以及风险
--->
- custom-cell-style 中提供了 updateCustomCell 函数，通过调用 registerCustomCellStyle 和 arrangeCustomCellStyle 解决更新的问题
- updateOption 中使用 updateCustomCell 函数去更新 customCellStyle 及 customCellStyleArrangement

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ 自测

⚠️ 在提交 PR 之前，请检查一下内容. ⚠️

- [ ] 文档提供了，或者更新，或者不需要
- [ ] Demo 提供了，或者更新，或者不需要
- [ ] Ts 类型定义提供了，或者更新，或者不需要
- [ ] Changelog 提供了，或者不需要

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough