### PR TITLE
fix: tab key navigation behavior

### DIFF
--- a/packages/vtable/src/event/listener/container-dom.ts
+++ b/packages/vtable/src/event/listener/container-dom.ts
@@ -120,6 +120,7 @@ export function bindContainerDomListener(eventManager: EventManager) {
       }
     } else if (e.key === 'Escape') {
       (table as ListTableAPI).editorManager?.cancelEdit();
+      table.getElement().focus();
     } else if (e.key === 'Enter') {
       // 如果按enter键 可以结束当前的编辑 或开启编辑选中的单元格（仅限单选）
       if ((table as ListTableAPI).editorManager?.editingEditor) {

--- a/packages/vtable/src/event/listener/container-dom.ts
+++ b/packages/vtable/src/event/listener/container-dom.ts
@@ -167,15 +167,21 @@ export function bindContainerDomListener(eventManager: EventManager) {
       }
     } else if (e.key === 'Tab') {
       if (table.options.keyboardOptions?.moveFocusCellOnTab ?? true) {
-        e.preventDefault();
         if (stateManager.select.cellPos.col >= 0 && stateManager.select.cellPos.row >= 0) {
+          const isLastCell =
+            stateManager.select.cellPos.col === table.colCount - 1 &&
+            stateManager.select.cellPos.row === table.rowCount - 1;
+
+          if (isLastCell) {
+            return;
+          }
+
+          e.preventDefault();
+
           let targetCol;
           let targetRow;
           if (stateManager.select.cellPos.col === table.colCount - 1) {
             targetRow = Math.min(table.rowCount - 1, stateManager.select.cellPos.row + 1);
-            targetCol = table.rowHeaderLevelCount;
-          } else if (stateManager.select.cellPos.row === table.rowCount - 1) {
-            targetRow = table.rowCount - 1;
             targetCol = table.rowHeaderLevelCount;
           } else {
             targetRow = stateManager.select.cellPos.row;


### PR DESCRIPTION
### 🤔 This is a Bug fix

### 🔗 Related issue link

close #2732 

### 💡 Background and solution

1. 问题描述：选中表格最后一行的任意单元格，按下Tab键时，之前的行为是会跳转到最后一行的第一列，这不符合用户预期。用户希望能够通过Tab键自然地跳转到下一列，如果是表格的最后一行最后一列，则跳转到页面的下一个可聚焦元素。

2. 解决方案：
   - 增加对最后一个单元格的判断
   - 在最后一个单元格时不阻止Tab键的默认行为
   - 删除了在最后一行时重置列位置的特殊处理，使Tab键导航逻辑更简单直接

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Optimize Tab key behavior: When the Tab key is pressed on the last row of the table, it will naturally focus on the next column, and if it is the last column of the last row, it will naturally focus on the next focusable element on the page, rather than resetting to the first column |
| 🇨🇳 Chinese | 优化Tab键行为：在表格最后一行按下Tab键时，会自然地聚焦到下一列，如果是最后一行最后一列则会自然地聚焦到页面上的下一个可聚焦元素，而不是重置到第一列 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### 🚀 Summary

This PR optimizes the Tab key navigation behavior in VTable, making it more intuitive and consistent with standard web practices.

### 🔍 Walkthrough

The changes include:
1. Adding a check for the last cell in the table
2. Preserving default Tab behavior when on the last cell
3. Removing special row position reset logic

These changes improve the overall keyboard navigation experience while maintaining code simplicity.
