### PR TITLE
docs: update auto-wrap-text demo

### DIFF
--- a/docs/assets/demo/en/basic-functionality/auto-wrap-text.md
+++ b/docs/assets/demo/en/basic-functionality/auto-wrap-text.md
@@ -10,76 +10,75 @@ option: ListTable#autoWrapText
 
 # line wrapping
 
-Auto-wrap is turned on. When the column width changes, the text will automatically calculate the display content according to the width. When using this function, you need to enable autoRowHeight to display the wrapped text.
+Auto-wrap is turned on. When the column width changes, the text will automatically calculate the display content according to the width. When using this function, you need to set `heightMode: 'autoHeight'` to display the wrapped text.
 
 ## Key Configurations
 
-*   'AutoWrapText: true 'Enable line wrapping
+- 'AutoWrapText: true 'Enable line wrapping
 
 ## Code demo
 
 ```javascript livedemo template=vtable
 let tableInstance;
-  fetch('https://lf9-dp-fe-cms-tos.byteorg.com/obj/bit-cloud/VTable/North_American_Superstore_data.json')
-    .then((res) => res.json())
-    .then((data) => {
+fetch('https://lf9-dp-fe-cms-tos.byteorg.com/obj/bit-cloud/VTable/North_American_Superstore_data.json')
+  .then(res => res.json())
+  .then(data => {
+    const columns = [
+      {
+        field: 'Order ID',
+        title: 'Order ID'
+      },
+      {
+        field: 'Customer ID',
+        title: 'Customer ID'
+      },
+      {
+        field: 'Product Name',
+        title: 'Product Name'
+      },
+      {
+        field: 'Category',
+        title: 'Category'
+      },
+      {
+        field: 'Sub-Category',
+        title: 'Sub-Category'
+      },
+      {
+        field: 'Region',
+        title: 'Region'
+      },
+      {
+        field: 'City',
+        title: 'City'
+      },
+      {
+        field: 'Order Date',
+        title: 'Order Date'
+      },
+      {
+        field: 'Quantity',
+        title: 'Quantity'
+      },
+      {
+        field: 'Sales',
+        title: 'Sales'
+      },
+      {
+        field: 'Profit',
+        title: 'Profit'
+      }
+    ];
 
-const columns =[
-    {
-        "field": "Order ID",
-        "title": "Order ID",
-    },
-    {
-        "field": "Customer ID",
-        "title": "Customer ID",
-    },
-    {
-        "field": "Product Name",
-        "title": "Product Name",
-    },
-    {
-        "field": "Category",
-        "title": "Category",
-    },
-    {
-        "field": "Sub-Category",
-        "title": "Sub-Category",
-    },
-    {
-        "field": "Region",
-        "title": "Region",
-    },
-    {
-        "field": "City",
-        "title": "City",
-    },
-    {
-        "field": "Order Date",
-        "title": "Order Date",
-    },
-    {
-        "field": "Quantity",
-        "title": "Quantity",
-    },
-    {
-        "field": "Sales",
-        "title": "Sales",
-    },
-    {
-        "field": "Profit",
-        "title": "Profit",
-    }
-];
-
-const option = {
-  records:data,
-  columns,
-  widthMode:'standard',
-  autoWrapText:true,
-  autoRowHeight:true,
-  defaultColWidth:150,
-};
-tableInstance = new VTable.ListTable(document.getElementById(CONTAINER_ID), option);
-window['tableInstance'] = tableInstance;
-    })
+    const option = {
+      records: data,
+      columns,
+      widthMode: 'standard',
+      autoWrapText: true,
+      heightMode: 'autoHeight',
+      defaultColWidth: 150
+    };
+    tableInstance = new VTable.ListTable(document.getElementById(CONTAINER_ID), option);
+    window['tableInstance'] = tableInstance;
+  });
 ```

--- a/docs/assets/demo/zh/basic-functionality/auto-wrap-text.md
+++ b/docs/assets/demo/zh/basic-functionality/auto-wrap-text.md
@@ -10,7 +10,7 @@ option: ListTable#autoWrapText
 
 # 自动换行
 
-开启了自动换行，当列宽有变化时，文本会根据宽度来自动计算展示内容。在使用此功能时，需要配合开启autoRowHeight，才能将折行文字显示出来。
+开启了自动换行，当列宽有变化时，文本会根据宽度来自动计算展示内容。在使用此功能时，需要配合设置 `heightMode: 'autoHeight'`，才能将折行文字显示出来。
 
 ## 关键配置
 
@@ -19,67 +19,66 @@ option: ListTable#autoWrapText
 ## 代码演示
 
 ```javascript livedemo template=vtable
-let  tableInstance;
-  fetch('https://lf9-dp-fe-cms-tos.byteorg.com/obj/bit-cloud/VTable/North_American_Superstore_data.json')
-    .then((res) => res.json())
-    .then((data) => {
+let tableInstance;
+fetch('https://lf9-dp-fe-cms-tos.byteorg.com/obj/bit-cloud/VTable/North_American_Superstore_data.json')
+  .then(res => res.json())
+  .then(data => {
+    const columns = [
+      {
+        field: 'Order ID',
+        title: 'Order ID'
+      },
+      {
+        field: 'Customer ID',
+        title: 'Customer ID'
+      },
+      {
+        field: 'Product Name',
+        title: 'Product Name'
+      },
+      {
+        field: 'Category',
+        title: 'Category'
+      },
+      {
+        field: 'Sub-Category',
+        title: 'Sub-Category'
+      },
+      {
+        field: 'Region',
+        title: 'Region'
+      },
+      {
+        field: 'City',
+        title: 'City'
+      },
+      {
+        field: 'Order Date',
+        title: 'Order Date'
+      },
+      {
+        field: 'Quantity',
+        title: 'Quantity'
+      },
+      {
+        field: 'Sales',
+        title: 'Sales'
+      },
+      {
+        field: 'Profit',
+        title: 'Profit'
+      }
+    ];
 
-const columns =[
-    {
-        "field": "Order ID",
-        "title": "Order ID",
-    },
-    {
-        "field": "Customer ID",
-        "title": "Customer ID",
-    },
-    {
-        "field": "Product Name",
-        "title": "Product Name",
-    },
-    {
-        "field": "Category",
-        "title": "Category",
-    },
-    {
-        "field": "Sub-Category",
-        "title": "Sub-Category",
-    },
-    {
-        "field": "Region",
-        "title": "Region",
-    },
-    {
-        "field": "City",
-        "title": "City",
-    },
-    {
-        "field": "Order Date",
-        "title": "Order Date",
-    },
-    {
-        "field": "Quantity",
-        "title": "Quantity",
-    },
-    {
-        "field": "Sales",
-        "title": "Sales",
-    },
-    {
-        "field": "Profit",
-        "title": "Profit",
-    }
-];
-
-const option = {
-  records:data,
-  columns,
-  widthMode:'standard',
-  autoWrapText:true,
-  heightMode:'autoHeight',
-  defaultColWidth:150,
-};
-tableInstance = new VTable.ListTable(document.getElementById(CONTAINER_ID),option);
-window['tableInstance'] = tableInstance;
-    })
+    const option = {
+      records: data,
+      columns,
+      widthMode: 'standard',
+      autoWrapText: true,
+      heightMode: 'autoHeight',
+      defaultColWidth: 150
+    };
+    tableInstance = new VTable.ListTable(document.getElementById(CONTAINER_ID), option);
+    window['tableInstance'] = tableInstance;
+  });
 ```


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [x] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 💡 Background and solution

The auto-wrap-text demo is outdated, and the English and Chinese demos are inconsistent.

