### PR TITLE
fix: 修复甘特图执行updateScales时，grid宽度计算错误的问题

### DIFF
--- a/packages/vtable-gantt/src/scenegraph/grid.ts
+++ b/packages/vtable-gantt/src/scenegraph/grid.ts
@@ -13,8 +13,6 @@ export class Grid {
   y: number;
   width: number;
   height: number;
-  timelineDates: any;
-  colWidthPerDay: number;
   rowHeight: number;
   rowCount: number;
   group: Group;
@@ -34,8 +32,6 @@ export class Grid {
     this.y = scene._gantt.getAllHeaderRowsHeight();
     this.width = scene.tableGroup.attribute.width;
     this.height = scene.tableGroup.attribute.height - scene.timelineHeader.group.attribute.height;
-    this.timelineDates = scene._gantt.parsedOptions.reverseSortedTimelineScales[0].timelineDates;
-    this.colWidthPerDay = scene._gantt.parsedOptions.colWidthPerDay;
     this.rowHeight = scene._gantt.parsedOptions.rowHeight;
     this.rowCount = scene._gantt.itemCount;
     this.allGridWidth = scene._gantt._getAllColsWidth();
@@ -93,9 +89,11 @@ export class Grid {
       if (this.gridStyle?.verticalLine.lineWidth & 1) {
         x = 0.5;
       }
-      for (let i = 0; i < this.timelineDates?.length - 1; i++) {
-        const dateline = this.timelineDates[i];
-        x = x + Math.floor(this.colWidthPerDay * dateline.days);
+      const timelineDates = this._scene._gantt.parsedOptions.reverseSortedTimelineScales[0].timelineDates;
+      const colWidthPerDay = this._scene._gantt.parsedOptions.colWidthPerDay;
+      for (let i = 0; i < timelineDates?.length - 1; i++) {
+        const dateline = timelineDates[i];
+        x = x + Math.floor(colWidthPerDay * dateline.days);
         const line = createLine({
           pickable: false,
           stroke: this.gridStyle?.verticalLine.lineColor,


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/VisActor/VTable/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link

### 💡 Background and solution
<img width="488" alt="image" src="https://github.com/user-attachments/assets/631c8a4b-71ea-4392-b1fe-9a8232b1eba3">
如上图，调用updateScales后，grid宽度计算错误，跟日期对不齐。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
