### PR TITLE
fix: 修复甘特图自定义taskbar时，拖拽taskbar报错的问题

### DIFF
--- a/packages/vtable-gantt/src/scenegraph/task-bar.ts
+++ b/packages/vtable-gantt/src/scenegraph/task-bar.ts
@@ -151,6 +151,7 @@ export class TaskBar {
       cornerRadius: this._scene._gantt.parsedOptions.taskBarStyle.cornerRadius,
       clip: true
     });
+    barGroup.name = 'task-bar-group';
     barGroupBox.appendChild(barGroup);
     barGroupBox.clipGroupBox = barGroup;
     let rootContainer;

--- a/packages/vtable-gantt/src/state/state-manager.ts
+++ b/packages/vtable-gantt/src/state/state-manager.ts
@@ -922,12 +922,17 @@ function reCreateCustomNode(gantt: Gantt, taskBarGroup: Group, taskIndex: number
     if (customLayoutObj) {
       const rootContainer = customLayoutObj.rootContainer;
       rootContainer.name = 'task-bar-custom-render';
-      const oldCustomIndex = taskBarGroup.children.findIndex((node: any) => {
-        return node.name === 'task-bar-custom-render';
-      });
-      const oldCustomNode = taskBarGroup.children[oldCustomIndex] as Group;
-      taskBarGroup.removeChild(oldCustomNode);
-      taskBarGroup.insertInto(rootContainer, oldCustomIndex);
+      const barGroup = taskBarGroup.children.find((node: any) => node.name === 'task-bar-group');
+      if (barGroup) {
+        const oldCustomIndex = barGroup.children.findIndex((node: any) => {
+          return node.name === 'task-bar-custom-render';
+        });
+        const oldCustomNode = barGroup.children[oldCustomIndex] as Group;
+        if (oldCustomNode) {
+          barGroup.removeChild(oldCustomNode);
+          barGroup.insertInto(rootContainer, oldCustomIndex);
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/VisActor/VTable/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link


### 💡 Background and solution

当甘特图使用customlayout自定义taskbar时，拖拽taskbar左侧或右侧，会报错。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
