### PR TITLE
fix: update options when record changed

### DIFF
--- a/packages/vtable-gantt/src/Gantt.ts
+++ b/packages/vtable-gantt/src/Gantt.ts
@@ -40,6 +40,7 @@ import {
   getHorizontalScrollBarSize,
   getVerticalScrollBarSize,
   initOptions,
+  updateOptionsWhenRecordChanged,
   updateOptionsWhenScaleChanged,
   updateSplitLineAndResizeLine
 } from './gantt-helper';
@@ -901,6 +902,7 @@ export class Gantt extends EventTarget {
   }
   setRecords(records: any[]) {
     this.records = records;
+    updateOptionsWhenRecordChanged(this);
     this.data.setRecords(records);
     this.taskListTableInstance.setRecords(records);
     this._syncPropsFromTable();

--- a/packages/vtable-gantt/src/gantt-helper.ts
+++ b/packages/vtable-gantt/src/gantt-helper.ts
@@ -989,3 +989,22 @@ export function formatRecordDateConsiderHasHour(
   }
   return { startDate: createDateAtMidnight(startDate, true), endDate: createDateAtLastHour(endDate, true) };
 }
+
+export function updateOptionsWhenRecordChanged(gantt: Gantt) {
+  const options = gantt.options;
+  const { unit: minTimeUnit, startOfWeek } = gantt.parsedOptions.reverseSortedTimelineScales[0];
+  gantt.parsedOptions.markLine = generateMarkLine(options?.markLine);
+  if (gantt.parsedOptions.markLine?.length ?? 0) {
+    if (gantt.parsedOptions.markLine?.every(item => item.scrollToMarkLine === undefined)) {
+      gantt.parsedOptions.markLine[0].scrollToMarkLine = true;
+    }
+    if (gantt.parsedOptions.markLine?.find(item => item.scrollToMarkLine)) {
+      gantt.parsedOptions.scrollToMarkLineDate = getStartDateByTimeUnit(
+        new Date(gantt.parsedOptions.markLine?.find(item => item.scrollToMarkLine).date),
+        minTimeUnit,
+        startOfWeek
+      );
+    }
+  }
+  gantt.parsedOptions.dependencyLinks = options.dependency?.links;
+}


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/VisActor/VTable/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x ] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link


### 💡 Background and solution
当执行setRecords时，如果依赖关系有变化，这时候页面会报错。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
