### PR TITLE
fix: update list table option replace release

### DIFF
--- a/packages/vtable-gantt/src/Gantt.ts
+++ b/packages/vtable-gantt/src/Gantt.ts
@@ -304,40 +304,45 @@ export class Gantt extends EventTarget {
       this.tableNoFrameHeight = height - lineWidth * 2;
     }
   }
+  _updateListTableSize(taskListTableInstance: ListTable) {
+    if (!taskListTableInstance) {
+      return;
+    }
+    if (this.options?.taskListTable?.tableWidth === 'auto' || this.taskTableWidth === -1) {
+      this.taskTableWidth =
+        taskListTableInstance.getAllColsWidth() + this.parsedOptions.outerFrameStyle.borderLineWidth;
+      if (this.options?.taskListTable?.maxTableWidth) {
+        this.taskTableWidth = Math.min(this.options?.taskListTable?.maxTableWidth, this.taskTableWidth);
+      }
+      if (this.options?.taskListTable?.minTableWidth) {
+        this.taskTableWidth = Math.max(this.options?.taskListTable?.minTableWidth, this.taskTableWidth);
+      }
+      this.element.style.left = this.taskTableWidth ? `${this.taskTableWidth}px` : '0px';
+      taskListTableInstance.setCanvasSize(
+        this.taskTableWidth,
+        this.tableNoFrameHeight + this.parsedOptions.outerFrameStyle.borderLineWidth * 2
+      );
+      this._updateSize();
+    }
+
+    if (taskListTableInstance.columnHeaderLevelCount > 1) {
+      if (taskListTableInstance.columnHeaderLevelCount === this.parsedOptions.timeLineHeaderRowHeights.length) {
+        for (let i = 0; i < taskListTableInstance.columnHeaderLevelCount; i++) {
+          taskListTableInstance.setRowHeight(i, this.parsedOptions.timeLineHeaderRowHeights[i]);
+        }
+      } else {
+        const newRowHeight = this.getAllHeaderRowsHeight() / taskListTableInstance.columnHeaderLevelCount;
+        for (let i = 0; i < taskListTableInstance.columnHeaderLevelCount; i++) {
+          taskListTableInstance.setRowHeight(i, newRowHeight);
+        }
+      }
+    }
+  }
   _generateListTable() {
     if (this.taskTableColumns.length >= 1 || this.options?.rowSeriesNumber) {
       const listTableOption = this._generateListTableOptions();
       this.taskListTableInstance = new ListTable(this.container, listTableOption);
-
-      if (this.options?.taskListTable?.tableWidth === 'auto' || this.taskTableWidth === -1) {
-        this.taskTableWidth =
-          this.taskListTableInstance.getAllColsWidth() + this.parsedOptions.outerFrameStyle.borderLineWidth;
-        if (this.options?.taskListTable?.maxTableWidth) {
-          this.taskTableWidth = Math.min(this.options?.taskListTable?.maxTableWidth, this.taskTableWidth);
-        }
-        if (this.options?.taskListTable?.minTableWidth) {
-          this.taskTableWidth = Math.max(this.options?.taskListTable?.minTableWidth, this.taskTableWidth);
-        }
-        this.element.style.left = this.taskTableWidth ? `${this.taskTableWidth}px` : '0px';
-        this.taskListTableInstance.setCanvasSize(
-          this.taskTableWidth,
-          this.tableNoFrameHeight + this.parsedOptions.outerFrameStyle.borderLineWidth * 2
-        );
-        this._updateSize();
-      }
-
-      if (this.taskListTableInstance.columnHeaderLevelCount > 1) {
-        if (this.taskListTableInstance.columnHeaderLevelCount === this.parsedOptions.timeLineHeaderRowHeights.length) {
-          for (let i = 0; i < this.taskListTableInstance.columnHeaderLevelCount; i++) {
-            this.taskListTableInstance.setRowHeight(i, this.parsedOptions.timeLineHeaderRowHeights[i]);
-          }
-        } else {
-          const newRowHeight = this.getAllHeaderRowsHeight() / this.taskListTableInstance.columnHeaderLevelCount;
-          for (let i = 0; i < this.taskListTableInstance.columnHeaderLevelCount; i++) {
-            this.taskListTableInstance.setRowHeight(i, newRowHeight);
-          }
-        }
-      }
+      this._updateListTableSize(this.taskListTableInstance);
     }
   }
   _generateListTableOptions() {
@@ -930,7 +935,6 @@ export class Gantt extends EventTarget {
   }
 
   updateOption(options: GanttConstructorOptions) {
-    this.taskListTableInstance?.release(); //这里省事用了先释放再重新创建的方式  也可以考虑调用listTable的updateOption
     (this.parsedOptions as any) = {};
     this.options = options;
 
@@ -950,7 +954,11 @@ export class Gantt extends EventTarget {
 
     this._updateSize();
 
-    this._generateListTable();
+    if (this.taskListTableInstance) {
+      const listTableOption = this._generateListTableOptions();
+      this.taskListTableInstance.updateOption(listTableOption);
+      this._updateListTableSize(this.taskListTableInstance);
+    }
     this._syncPropsFromTable();
 
     updateSplitLineAndResizeLine(this);


### PR DESCRIPTION

[[中文版模板 / Chinese template](https://github.com/VisActor/VTable/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x ] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 💡 Background and solution
甘特图updateOption直接将tableInstance release会有问题。譬如在react中，可能还存在对旧的tableInstance的引用，直接release掉，会导致EventTarget中的也release，这时候listenersData就为空了。执行旧tableInstance on的时候就会报错

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
