### PR TITLE
fix: updateLinkLinePoints with date is null

### DIFF
--- a/packages/vtable-gantt/src/scenegraph/scenegraph.ts
+++ b/packages/vtable-gantt/src/scenegraph/scenegraph.ts
@@ -537,6 +537,16 @@ export class Scenegraph {
           taskDays: linkedFromTaskTaskDays
         } = gantt.getTaskInfoByTaskListIndex(linkedFromTaskShowIndex));
       }
+      if (
+        !linkedFromTaskStartDate ||
+        !linkedFromTaskEndDate ||
+        !linkedToTaskStartDate ||
+        !linkedToTaskEndDate ||
+        !linkLineNode ||
+        !lineArrowNode
+      ) {
+        return;
+      }
       const { linePoints, arrowPoints } = updateLinkLinePoints(
         type,
         linkedFromTaskStartDate,
@@ -555,16 +565,6 @@ export class Scenegraph {
         0,
         this._gantt
       );
-      if (
-        !linkedFromTaskStartDate ||
-        !linkedFromTaskEndDate ||
-        !linkedToTaskStartDate ||
-        !linkedToTaskEndDate ||
-        !linkLineNode ||
-        !lineArrowNode
-      ) {
-        return;
-      }
       linkLineNode.setAttribute('points', linePoints);
       lineArrowNode.setAttribute('points', arrowPoints);
     }


### PR DESCRIPTION


[[中文版模板 / Chinese template](https://github.com/VisActor/VTable/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x ] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

修复当有依赖关系时，拖动taskbar，date为空时，会导致漂移的问题

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
