### PR TITLE
fix: update class names for Vue ArcoSelect components

### DIFF
--- a/docs/assets/demo-vue/en/edit-data/arco-select-editor.md
+++ b/docs/assets/demo-vue/en/edit-data/arco-select-editor.md
@@ -72,7 +72,7 @@ class ArcoListEditor {
             {
               default: () =>
                 this.options.map(option =>
-                  h(ArcoDesignVue.Option, { key: option, value: option }, { default: () => option })
+                  h(ArcoDesignVue.Option, { key: option, value: option, class: 'arco-select-vtable' }, { default: () => option })
                 )
             }
           )
@@ -115,7 +115,7 @@ class ArcoListEditor {
 
   isClickPopUp(target) {
     while (target) {
-      if (target.classList && target.classList.contains('arco-select-option')) {
+      if (target.classList && target.classList.contains('arco-select-vtable')) {
         return true;
       }
       target = target.parentNode;

--- a/docs/assets/demo-vue/zh/edit-data/arco-select-editor.md
+++ b/docs/assets/demo-vue/zh/edit-data/arco-select-editor.md
@@ -72,7 +72,7 @@ class ArcoListEditor {
             {
               default: () =>
                 this.options.map(option =>
-                  h(ArcoDesignVue.Option, { key: option, value: option }, { default: () => option })
+                  h(ArcoDesignVue.Option, { key: option, value: option, class: 'arco-select-vtable'}, { default: () => option })
                 )
             }
           )
@@ -115,7 +115,7 @@ class ArcoListEditor {
 
   isClickPopUp(target) {
     while (target) {
-      if (target.classList && target.classList.contains('arco-select-option')) {
+      if (target.classList && target.classList.contains('arco-select-vtable')) {
         return true;
       }
       target = target.parentNode;

--- a/packages/vue-vtable/demo/src/table/gramatical/composition/ListTable-editor-arco.vue
+++ b/packages/vue-vtable/demo/src/table/gramatical/composition/ListTable-editor-arco.vue
@@ -76,7 +76,7 @@ class ArcoListEditor {
           {
             default: () =>
               this.options.map((option: any) =>
-                h(AOption, { key: option, value: option }, { default: () => option })
+                h(AOption, { key: option, value: option, class: 'arco-select-vtable'}, { default: () => option })
               ),
           }
         ),
@@ -121,7 +121,7 @@ class ArcoListEditor {
 
   isClickPopUp(target: HTMLElement) {
     while (target) {
-      if (target.classList && target.classList.contains('arco-select-option')) {
+      if (target.classList && target.classList.contains('arco-select-vtable')) {
         return true;
       }
       target = target.parentNode as HTMLElement;


### PR DESCRIPTION
This pull request includes changes to the `ArcoListEditor` class across multiple files to update the class name for select options. The changes ensure consistency in the class name used for styling and event handling.

