### PR TITLE
fix: export data is current page size when if current mode is pagination

### DIFF
--- a/packages/vtable-export/src/csv/index.ts
+++ b/packages/vtable-export/src/csv/index.ts
@@ -12,9 +12,13 @@ export type ExportVTableToCsvOptions = {
   escape?: boolean;
 };
 
-export function exportVTableToCsv(tableInstance: IVTable, option?: ExportVTableToCsvOptions): string {
+export function exportVTableToCsv(
+  tableInstance: IVTable,
+  option?: ExportVTableToCsvOptions,
+  exportAllData: boolean = false
+): string {
   const minRow = 0;
-  const maxRow = tableInstance.rowCount - 1;
+  const maxRow = exportAllData ? (tableInstance.options.records.length as number) : tableInstance.rowCount - 1;
   const minCol = 0;
   const maxCol = tableInstance.colCount - 1;
 

--- a/packages/vtable-export/src/excel/index.ts
+++ b/packages/vtable-export/src/excel/index.ts
@@ -44,7 +44,8 @@ function requestIdleCallbackPromise(options?: IdleRequestOptions) {
 export async function exportVTableToExcel(
   tableInstance: IVTable,
   options?: ExportVTableToExcelOptions,
-  optimization = false
+  optimization = false,
+  exportAllData = false
 ) {
   const workbook = new ExcelJS.Workbook();
   const worksheet = workbook.addWorksheet('sheet1');
@@ -52,7 +53,7 @@ export async function exportVTableToExcel(
 
   const columns = [];
   const minRow = 0;
-  const maxRow = tableInstance.rowCount - 1;
+  const maxRow = exportAllData ? (tableInstance.options.records.length as number) : tableInstance.rowCount - 1;
   const minCol = 0;
   const maxCol = tableInstance.colCount - 1;
   const mergeCells = [];


### PR DESCRIPTION

[[中文版模板 / Chinese template](https://github.com/VisActor/VTable/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link
https://github.com/VisActor/VTable/issues/3726

### 💡 Background and solution
1. 当设置分页模式时，导出部分数据
2. 解决方案为提供exportAllData参数，支持导出当前页或全量数据

### 📝 Changelog


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
