### PR TITLE
feat: add vue-table export type /es/*.d.ts

### DIFF
--- a/common/changes/@visactor/vtable/develop_2025-05-22-08-21.json
+++ b/common/changes/@visactor/vtable/develop_2025-05-22-08-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "feat: add vue-table export type /es/*.d.ts\n\n",
+      "type": "none",
+      "packageName": "@visactor/vtable"
+    }
+  ],
+  "packageName": "@visactor/vtable",
+  "email": "48147837+kcmeven@users.noreply.github.com"
+}

--- a/packages/vue-vtable/package.json
+++ b/packages/vue-vtable/package.json
@@ -33,6 +33,13 @@
     ".": {
       "require": "./cjs/index.js",
       "import": "./es/index.js"
+    },
+    "./es/*": {
+      "types": [
+        "./es/*.d.ts",
+        "./es/*/index.d.ts"
+      ],
+      "import": "./es/*.js"
     }
   },
   "scripts": {


### PR DESCRIPTION

### 🤔 这个分支是...

- [ ] 新功能
- [ ] Bug fix
- [ ] Ts 类型更新
- [ ] 打包优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 重构
- [ ] 依赖版本更新
- [ ] 代码优化
- [ ] 测试 case 更新
- [ ] 分支合并
- [ ] 网站/文档更新
- [ ] demo 更新
- [ ] Workflow
- [x] 配置修改
- [ ] 发布
- [ ] 其他 (具体是什么，请补充?)

### 🔗 相关 issue 连接
 
https://github.com/VisActor/VTable/issues/3922

### 💡 问题的背景&解决方案

在tsconfig中设置 "moduleResolution": "bundler", node16 nodenext下
`import type { EventsProps } from '@visactor/vue-vtable/es/eventsUtils'`
会提示找不到模块“@visactor/vue-vtable/es/eventsUtils”或其相应的类型声明。ts(2307)

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  add vue-table export type /es/*.d.ts    |
| 🇨🇳 Chinese |   增加vue-table导出类型      |

### ☑️ 自测

⚠️ 在提交 PR 之前，请检查一下内容. ⚠️

- [ ] 文档提供了，或者更新，或者不需要
- [ ] Demo 提供了，或者更新，或者不需要
- [ ] Ts 类型定义提供了，或者更新，或者不需要
- [x] Changelog 提供了，或者不需要

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough