### PR TITLE
fix: column widths display incorrectly after updateColmns

### DIFF
--- a/packages/vtable/src/ListTable.ts
+++ b/packages/vtable/src/ListTable.ts
@@ -223,6 +223,7 @@ export class ListTable extends BaseTable implements ListTableAPI {
     //     this.internalProps.columns[index].editor = colDefine.editor;
     //   }
     // });
+    this.internalProps._widthResizedColMap.clear();
     this.options.columns = columns;
     this.internalProps.headerHelper.setTableColumnsEditor();
     this._hasAutoImageColumn = undefined;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/VTable/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [✅] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    Fixed column width reallocation issue when updateColumns is called after manual resizing       |
| 🇨🇳 Chinese |    修复手动调整列宽后 updateColumns 无法触发列宽重新分配的问题       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary
执行updateColumns时
- 在this.scenegraph.createSceneGraph() 方法中跳过了调整过列宽的列
- 在调用函数computeColWidth时，调整过宽度的列会沿用列宽
因此可以通过清空_widthResizedColMap来实现updateColumns时重新触发宽度分配 
```
this.internalProps._widthResizedColMap.clear();
```


​Scene Graph Construction Phase​
this.scenegraph.createSceneGraph() skipped columns with manually adjusted widths (marked in _widthResizedColMap).
​Column Width Calculation Phase​
When calling computeColWidth, pre-adjusted columns reused their old width values instead of recalculating.
​Solution:
Clear width adjustment records during updateColumns:
```
this.internalProps._widthResizedColMap.clear();  
```


### 🔍 Walkthrough

copilot:walkthrough
