### PR TITLE
fix: right click cannot preserve inverse selection

### DIFF
--- a/packages/vtable/src/event/self-event-listener/base-table/right-button-click.ts
+++ b/packages/vtable/src/event/self-event-listener/base-table/right-button-click.ts
@@ -10,7 +10,16 @@ export function rightButtonClickEvent(table: BaseTableAPI) {
     if (ranges.length > 0) {
       for (let i = 0; i < ranges.length; i++) {
         const range = ranges[i];
-        if (col >= range.start.col && col <= range.end.col && row >= range.start.row && row <= range.end.row) {
+        const startCol = range.start.col;
+        const endCol = range.end.col;
+        const startRow = range.start.row;
+        const endRow = range.end.row;
+        if (
+          (col >= startCol && col <= endCol && row >= startRow && row <= endRow) || // 左上向右下选择
+          (col >= endCol && col <= startCol && row >= endRow && row <= startRow) || // 右下向左上选择
+          (col >= startCol && col <= endCol && row >= endRow && row <= startRow) || // 左下向右上选择
+          (col >= endCol && col <= startCol && row >= startRow && row <= endRow) // 右上向左下选择
+        ) {
           cellInRange = true;
           break;
         }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/VTable/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link

related https://github.com/VisActor/VTable/issues/3945
fix #3945

### 💡 Background and solution

一个选区，可以能来自四个方向的选择。当前点击右键时，只保留了一个方向的选区，因此需要增加代码，从而保留其他3个方向选择的区域

### 📝 Changelog

点击右键时，可以保留任意方向选择的选区

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | 点击右键时，可以保留任意方向选择的选区  |
| 🇨🇳 Chinese | right-click can preserve the selection in any direction   |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
