### PR TITLE
fix: resolve mismatch between drag indices and update checkbox logic for groups issue 3975

### DIFF
--- a/docs/assets/api/en/methods.md
+++ b/docs/assets/api/en/methods.md
@@ -1649,6 +1649,44 @@ The pixelRatio can be obtained directly from the instance's pixelRatio property.
 /\*_ Set the canvas pixel ratio _/
 setPixelRatio: (pixelRatio: number) => void;
 
+````
+
+## expandAllTreeNode(Function)
+
+Expand all tree nodes (including headers and data rows).
+
+**ListTable Proprietary**
+
+```ts
+  /**
+   * Expand all tree nodes (including headers and data rows).
+   */
+  expandAllTreeNode(): void
+````
+
+Usage:
+
+```ts
+// Expand all nodes
+tableInstance.expandAllTreeNode();
 ```
 
+## collapseAllTreeNode(Function)
+
+Collapse all tree nodes (including headers and data rows).
+
+**ListTable Proprietary**
+
+```ts
+  /**
+   * Collapse all tree nodes (including headers and data rows).
+   */
+  collapseAllTreeNode(): void
+```
+
+Usage:
+
+```ts
+// Collapse all nodes
+tableInstance.collapseAllTreeNode();
 ```

--- a/docs/assets/api/zh/methods.md
+++ b/docs/assets/api/zh/methods.md
@@ -1462,3 +1462,43 @@ setLoadingHierarchyState: (col: number, row: number) => void;
   /** 设置画布的像素比 */
   setPixelRatio: (pixelRatio: number) => void;
 ```
+
+## expandAllTreeNode(Function)
+
+展开所有树形节点（包括表头和数据行）。
+
+**ListTable 专有**
+
+```ts
+  /**
+   * 展开所有树形节点（包括表头和数据行）。
+   */
+  expandAllTreeNode(): void
+```
+
+使用：
+
+```ts
+// 展开所有节点
+tableInstance.expandAllTreeNode();
+```
+
+## collapseAllTreeNode(Function)
+
+折叠所有树形节点（包括表头和数据行）。
+
+**ListTable 专有**
+
+```ts
+  /**
+   * 折叠所有树形节点（包括表头和数据行）。
+   */
+  collapseAllTreeNode(): void
+```
+
+使用：
+
+```ts
+// 折叠所有节点
+tableInstance.collapseAllTreeNode();
+```

--- a/packages/vtable/examples/list/list-checkbox-tree-moveRow.ts
+++ b/packages/vtable/examples/list/list-checkbox-tree-moveRow.ts
@@ -1,0 +1,256 @@
+import * as VTable from '../../src';
+import { bindDebugTool } from '../../src/scenegraph/debug-tool';
+const ListTable = VTable.ListTable;
+const CONTAINER_ID = 'vTable';
+
+export function createTable() {
+  const data = [
+    {
+      类别: '办公用品',
+      销售额: '129.696',
+      数量: '2',
+      利润: '60.704',
+      children: [
+        {
+          类别: '信封', // 对应原子类别
+          销售额: '125.44',
+          数量: '2',
+          利润: '42.56',
+          children: [
+            {
+              类别: '黄色信封',
+              销售额: '125.44',
+              数量: '2',
+              利润: '42.56',
+              children: [
+                {
+                  类别: '黄色大信封',
+                  销售额: '1375.92',
+                  数量: '3',
+                  利润: '550.2'
+                },
+                {
+                  类别: '黄色小信封',
+                  销售额: '1375.92',
+                  数量: '3',
+                  利润: '550.2'
+                }
+              ]
+            },
+            {
+              类别: '白色信封',
+              销售额: '1375.92',
+              数量: '3',
+              利润: '550.2'
+            }
+          ]
+        },
+        {
+          类别: '器具', // 对应原子类别
+          销售额: '1375.92',
+          数量: '3',
+          利润: '550.2',
+          children: [
+            {
+              类别: '订书机',
+              销售额: '125.44',
+              数量: '2',
+              利润: '42.56'
+            },
+            {
+              类别: '计算器',
+              销售额: '1375.92',
+              数量: '3',
+              利润: '550.2'
+            }
+          ]
+        }
+      ]
+    },
+    {
+      类别: '技术',
+      销售额: '229.696',
+      数量: '20',
+      利润: '90.704',
+      children: [
+        {
+          类别: '设备', // 对应原子类别
+          销售额: '225.44',
+          数量: '5',
+          利润: '462.56'
+        },
+        {
+          类别: '配件', // 对应原子类别
+          销售额: '375.92',
+          数量: '8',
+          利润: '550.2'
+        },
+        {
+          类别: '复印机', // 对应原子类别
+          销售额: '425.44',
+          数量: '7',
+          利润: '34.56'
+        },
+        {
+          类别: '电话', // 对应原子类别
+          销售额: '175.92',
+          数量: '6',
+          利润: '750.2'
+        }
+      ]
+    },
+    {
+      类别: '家具',
+      销售额: '129.696',
+      数量: '2',
+      利润: '-60.704',
+      children: [
+        {
+          类别: '桌子', // 对应原子类别
+          销售额: '125.44',
+          数量: '2',
+          利润: '42.56',
+          children: [
+            {
+              类别: '黄色桌子',
+              销售额: '125.44',
+              数量: '2',
+              利润: '42.56'
+            },
+            {
+              类别: '白色桌子',
+              销售额: '1375.92',
+              数量: '3',
+              利润: '550.2'
+            }
+          ]
+        },
+        {
+          类别: '椅子', // 对应原子类别
+          销售额: '1375.92',
+          数量: '3',
+          利润: '550.2',
+          children: [
+            {
+              类别: '老板椅',
+              销售额: '125.44',
+              数量: '2',
+              利润: '42.56'
+            },
+            {
+              类别: '沙发椅',
+              销售额: '1375.92',
+              数量: '3',
+              利润: '550.2'
+            }
+          ]
+        }
+      ]
+    },
+    {
+      类别: '生活家电（懒加载）',
+      销售额: '229.696',
+      数量: '20',
+      利润: '90.704',
+      children: true
+    }
+  ];
+  const option: VTable.ListTableConstructorOptions = {
+    container: document.getElementById(CONTAINER_ID),
+    columns: [
+      {
+        field: '类别',
+        tree: true,
+        cellType: 'checkbox',
+        // headerType: 'checkbox',
+        title: '类别',
+        width: 'auto',
+        sort: true
+      },
+      {
+        cellType: 'radio',
+        field: '销售额',
+        title: '销售额',
+        width: 'auto',
+        sort: true
+        // tree: true,
+      },
+      {
+        field: '利润',
+        title: '利润',
+        width: 'auto',
+        sort: true
+      }
+    ],
+    showFrozenIcon: true, //显示VTable内置冻结列图标
+    widthMode: 'standard',
+    // autoFillHeight: true,
+    // heightMode: 'adaptive',
+    allowFrozenColCount: 2,
+    records: data,
+
+    hierarchyIndent: 20,
+    hierarchyExpandLevel: 2,
+
+    // sortState: {
+    //   field: '销售额',
+    //   order: 'desc'
+    // },
+    theme: VTable.themes.BRIGHT,
+    defaultRowHeight: 32,
+    select: {
+      disableDragSelect: true
+    },
+    // transpose: true,
+    rowSeriesNumber: {
+      dragOrder: true
+      // enableTreeCheckbox: true
+    }
+    // enableCheckboxCascade: true
+  };
+
+  const instance = new ListTable(option);
+  window.tableInstance = instance;
+  bindDebugTool(instance.scenegraph.stage, { customGrapicKeys: ['col', 'row'] });
+
+  const { TREE_HIERARCHY_STATE_CHANGE } = VTable.ListTable.EVENT_TYPE;
+  instance.on(TREE_HIERARCHY_STATE_CHANGE, args => {
+    // TODO 调用接口插入设置子节点的数据
+    if (args.hierarchyState === VTable.TYPES.HierarchyState.expand && !Array.isArray(args.originData.children)) {
+      const record = args.originData;
+      instance.setLoadingHierarchyState(args.col, args.row);
+      setTimeout(() => {
+        const children = [
+          {
+            类别: record['类别'] + ' - 分类1', // 对应原子类别
+            销售额: 2,
+            数量: 5,
+            利润: 4
+          },
+          {
+            类别: record['类别'] + ' - 分类2', // 对应原子类别
+            销售额: 3,
+            数量: 8,
+            利润: 5
+          },
+          {
+            类别: record['类别'] + ' - 分类3（懒加载）',
+            销售额: 4,
+            数量: 20,
+            利润: 90.704,
+            children: true
+          },
+          {
+            类别: record['类别'] + ' - 分类4', // 对应原子类别
+            销售额: 5,
+            数量: 6,
+            利润: 7
+          }
+        ];
+        instance.setRecordChildren(children, args.col, args.row);
+      }, 2000);
+    }
+  });
+
+  window.tableInstance = instance;
+}

--- a/packages/vtable/examples/list/list-tree-expandAndCollapseAll.ts
+++ b/packages/vtable/examples/list/list-tree-expandAndCollapseAll.ts
@@ -1,0 +1,256 @@
+import * as VTable from '../../src';
+import { bindDebugTool } from '../../src/scenegraph/debug-tool';
+const ListTable = VTable.ListTable;
+const CONTAINER_ID = 'vTable';
+
+export function createTable() {
+  const data = [
+    {
+      类别: '办公用品',
+      销售额: '129.696',
+      数量: '2',
+      利润: '60.704',
+      children: [
+        {
+          类别: '信封', // 对应原子类别
+          销售额: '125.44',
+          数量: '2',
+          利润: '42.56',
+          children: [
+            {
+              类别: '黄色信封',
+              销售额: '125.44',
+              数量: '2',
+              利润: '42.56'
+            },
+            {
+              类别: '白色信封',
+              销售额: '1375.92',
+              数量: '3',
+              利润: '550.2'
+            }
+          ]
+        },
+        {
+          类别: '器具', // 对应原子类别
+          销售额: '1375.92',
+          数量: '3',
+          利润: '550.2',
+          children: [
+            {
+              类别: '订书机',
+              销售额: '125.44',
+              数量: '2',
+              利润: '42.56'
+            },
+            {
+              类别: '计算器',
+              销售额: '1375.92',
+              数量: '3',
+              利润: '550.2'
+            }
+          ]
+        }
+      ]
+    },
+    {
+      类别: '技术',
+      销售额: '229.696',
+      数量: '20',
+      利润: '90.704',
+      children: [
+        {
+          类别: '设备', // 对应原子类别
+          销售额: '225.44',
+          数量: '5',
+          利润: '462.56'
+        },
+        {
+          类别: '配件', // 对应原子类别
+          销售额: '375.92',
+          数量: '8',
+          利润: '550.2'
+        },
+        {
+          类别: '复印机', // 对应原子类别
+          销售额: '425.44',
+          数量: '7',
+          利润: '34.56'
+        },
+        {
+          类别: '电话', // 对应原子类别
+          销售额: '175.92',
+          数量: '6',
+          利润: '750.2'
+        }
+      ]
+    },
+    {
+      类别: '家具',
+      销售额: '129.696',
+      数量: '2',
+      利润: '-60.704',
+      children: [
+        {
+          类别: '桌子', // 对应原子类别
+          销售额: '125.44',
+          数量: '2',
+          利润: '42.56',
+          children: [
+            {
+              类别: '黄色桌子',
+              销售额: '125.44',
+              数量: '2',
+              利润: '42.56'
+            },
+            {
+              类别: '白色桌子',
+              销售额: '1375.92',
+              数量: '3',
+              利润: '550.2'
+            }
+          ]
+        },
+        {
+          类别: '椅子', // 对应原子类别
+          销售额: '1375.92',
+          数量: '3',
+          利润: '550.2',
+          children: [
+            {
+              类别: '老板椅',
+              销售额: '125.44',
+              数量: '2',
+              利润: '42.56'
+            },
+            {
+              类别: '沙发椅',
+              销售额: '1375.92',
+              数量: '3',
+              利润: '550.2'
+            }
+          ]
+        }
+      ]
+    },
+    {
+      类别: '生活家电（懒加载）',
+      销售额: '229.696',
+      数量: '20',
+      利润: '90.704',
+      children: true
+    }
+  ];
+  const option: VTable.ListTableConstructorOptions = {
+    container: document.getElementById(CONTAINER_ID),
+    columns: [
+      {
+        field: '类别',
+        tree: true,
+        title: '类别',
+        width: 'auto',
+        sort: true
+      },
+      {
+        field: '销售额',
+        title: '销售额',
+        width: 'auto',
+        sort: true
+        // tree: true,
+      },
+      {
+        field: '利润',
+        title: '利润',
+        width: 'auto',
+        sort: true
+      }
+    ],
+    showFrozenIcon: true, //显示VTable内置冻结列图标
+    widthMode: 'standard',
+    // autoFillHeight: true,
+    // heightMode: 'adaptive',
+    allowFrozenColCount: 2,
+    records: data,
+
+    hierarchyIndent: 20,
+    hierarchyExpandLevel: 2,
+
+    // sortState: {
+    //   field: '销售额',
+    //   order: 'desc'
+    // },
+    theme: VTable.themes.BRIGHT,
+    defaultRowHeight: 32,
+    select: {
+      disableDragSelect: true
+    }
+  };
+
+  const instance = new ListTable(option);
+
+  // add buttons to expand all and collapse all tree nodes
+  const buttonsContainer = document.createElement('div');
+  buttonsContainer.style.marginBottom = '10px';
+
+  const expandAllBtn = document.createElement('button');
+  expandAllBtn.innerText = '全部展开';
+  expandAllBtn.addEventListener('click', () => {
+    instance.expandAllTreeNode();
+  });
+  buttonsContainer.appendChild(expandAllBtn);
+
+  const collapseAllBtn = document.createElement('button');
+  collapseAllBtn.innerText = '全部折叠';
+  collapseAllBtn.style.marginLeft = '10px';
+  collapseAllBtn.addEventListener('click', () => {
+    instance.collapseAllTreeNode();
+  });
+  buttonsContainer.appendChild(collapseAllBtn);
+
+  document
+    .getElementById(CONTAINER_ID)
+    .parentElement.insertBefore(buttonsContainer, document.getElementById(CONTAINER_ID));
+
+  window.tableInstance = instance;
+  bindDebugTool(instance.scenegraph.stage, { customGrapicKeys: ['col', 'row'] });
+
+  const { TREE_HIERARCHY_STATE_CHANGE } = VTable.ListTable.EVENT_TYPE;
+  instance.on(TREE_HIERARCHY_STATE_CHANGE, args => {
+    if (args.hierarchyState === VTable.TYPES.HierarchyState.expand && !Array.isArray(args.originData.children)) {
+      const record = args.originData;
+      instance.setLoadingHierarchyState(args.col, args.row);
+      setTimeout(() => {
+        const children = [
+          {
+            类别: record['类别'] + ' - 分类1', // 对应原子类别
+            销售额: 2,
+            数量: 5,
+            利润: 4
+          },
+          {
+            类别: record['类别'] + ' - 分类2', // 对应原子类别
+            销售额: 3,
+            数量: 8,
+            利润: 5
+          },
+          {
+            类别: record['类别'] + ' - 分类3（懒加载）',
+            销售额: 4,
+            数量: 20,
+            利润: 90.704,
+            children: true
+          },
+          {
+            类别: record['类别'] + ' - 分类4', // 对应原子类别
+            销售额: 5,
+            数量: 6,
+            利润: 7
+          }
+        ];
+        instance.setRecordChildren(children, args.col, args.row);
+      }, 2000);
+    }
+  });
+
+  window.tableInstance = instance;
+}

--- a/packages/vtable/examples/list/list-tree-expandAndCollapseAll.ts
+++ b/packages/vtable/examples/list/list-tree-expandAndCollapseAll.ts
@@ -175,10 +175,10 @@ export function createTable() {
     hierarchyIndent: 20,
     hierarchyExpandLevel: 2,
 
-    // sortState: {
-    //   field: '销售额',
-    //   order: 'desc'
-    // },
+    sortState: {
+      field: '销售额',
+      order: 'desc'
+    },
     theme: VTable.themes.BRIGHT,
     defaultRowHeight: 32,
     select: {

--- a/packages/vtable/examples/menu.ts
+++ b/packages/vtable/examples/menu.ts
@@ -25,6 +25,10 @@ export const menus = [
       {
         path: 'debug',
         name: 'scroll'
+      },
+      {
+        path: 'debug',
+        name: 'list'
       }
     ]
   },
@@ -66,6 +70,10 @@ export const menus = [
       {
         path: 'list',
         name: 'list-checkbox-tree'
+      },
+      {
+        path: 'list',
+        name: 'list-checkbox-tree-moveRow'
       },
       {
         path: 'list',

--- a/packages/vtable/examples/menu.ts
+++ b/packages/vtable/examples/menu.ts
@@ -252,6 +252,10 @@ export const menus = [
       },
       {
         path: 'pivot',
+        name: 'pivot-moveRow'
+      },
+      {
+        path: 'pivot',
         name: 'pivot-rowSeriesNumber'
       },
       {

--- a/packages/vtable/examples/menu.ts
+++ b/packages/vtable/examples/menu.ts
@@ -65,6 +65,10 @@ export const menus = [
       },
       {
         path: 'list',
+        name: 'list-tree-expandAndCollapseAll'
+      },
+      {
+        path: 'list',
         name: 'list-checkbox-tree'
       },
       {

--- a/packages/vtable/examples/pivot/pivot-moveRow.ts
+++ b/packages/vtable/examples/pivot/pivot-moveRow.ts
@@ -1,0 +1,308 @@
+import * as VTable from '../../src';
+import { bindDebugTool } from '../../src/scenegraph/debug-tool';
+const PivotTable = VTable.PivotTable;
+const CONTAINER_ID = 'vTable';
+
+export function createTable() {
+  fetch('https://lf9-dp-fe-cms-tos.byteorg.com/obj/bit-cloud/VTable/North_American_Superstore_Pivot2_data.json')
+    .then(res => res.json())
+    .then(data => {
+      VTable.register.icon('book', {
+        type: 'svg', //指定svg格式图标，其他还支持path，image，font
+        svg: `<svg t="1669210190896" class="icon" viewBox="0 0 1427 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" p-id="4793" width="200" height="200"><path d="M1351.064977 123.555737h-107.862689V92.969424l-36.660345-14.396103C1199.192582 75.698424 1024.753324 7.932987 872.167608 7.932987c-71.440118 0-128.592212 14.720339-170.786193 43.880012-42.193982-29.159673-99.302844-43.880012-170.764578-43.880012-152.585716 0-327.024974 67.765437-334.374335 70.640334l-36.638729 14.396103v30.586313H54.291745A43.318002 43.318002 0 0 0 10.973743 166.873739v797.81643c0 23.928657 19.389345 43.318002 43.318002 43.318001h1296.773232a43.318002 43.318002 0 0 0 43.318002-43.318001V166.873739a43.318002 43.318002 0 0 0-43.318002-43.318002z m-165.620024 8.776003v633.169114c-89.446053-30.629545-327.003358-100.03778-455.184871-25.203987V102.566825c36.141566-26.998096 87.025087-36.898118 141.907526-36.898118 143.420629 0 313.277345 66.663033 313.277345 66.663033zM1120.035635 804.971249H739.295474c74.293399-70.467408 258.243596-36.595497 380.740161 0zM530.616837 65.668707c54.860823 0 105.765959 9.921638 141.88591 36.898118v637.730042c-128.181512-74.790562-365.695585-5.425558-455.163254 25.203987V132.33174s169.856715-66.663033 313.277344-66.663033z m132.850518 739.302542H282.662347c122.453333-36.638729 306.489993-70.575487 380.805008 0z m644.27962 116.400918H97.609746V210.170125h61.994027v652.536844H1243.202288V210.170125h64.544687v711.202042z" p-id="4794"></path></svg>`,
+        width: 20,
+        height: 20,
+        name: 'book',
+        positionType: VTable.TYPES.IconPosition.inlineEnd,
+        marginLeft: 2,
+        marginRight: 0,
+        visibleTime: 'always',
+        hover: {
+          width: 22,
+          height: 22,
+          bgColor: 'rgba(22,44,66,0.2)'
+        },
+        tooltip: {
+          title: '书籍',
+          placement: VTable.TYPES.Placement.left
+        }
+      });
+
+      const option: VTable.PivotTableConstructorOptions = {
+        container: document.getElementById(CONTAINER_ID),
+        records: data,
+        rowTree: [
+          {
+            dimensionKey: 'Category',
+            value: 'Furniture',
+            hierarchyState: 'expand',
+            children: [
+              {
+                dimensionKey: 'Sub-Category',
+                value: 'Bookcases',
+                hierarchyState: 'collapse'
+              },
+              {
+                dimensionKey: 'Sub-Category',
+                value: 'Chairs',
+                hierarchyState: 'collapse'
+              },
+              {
+                dimensionKey: 'Sub-Category',
+                value: 'Furnishings'
+              },
+              {
+                dimensionKey: 'Sub-Category',
+                value: 'Tables'
+              }
+            ]
+          },
+          {
+            dimensionKey: 'Category',
+            value: 'Office Supplies',
+            children: [
+              {
+                dimensionKey: 'Sub-Category',
+                value: 'Appliances'
+              },
+              {
+                dimensionKey: 'Sub-Category',
+                value: 'Art'
+              },
+              {
+                dimensionKey: 'Sub-Category',
+                value: 'Binders'
+              },
+              {
+                dimensionKey: 'Sub-Category',
+                value: 'Envelopes'
+              },
+              {
+                dimensionKey: 'Sub-Category',
+                value: 'Fasteners'
+              },
+              {
+                dimensionKey: 'Sub-Category',
+                value: 'Labels'
+              },
+              {
+                dimensionKey: 'Sub-Category',
+                value: 'Paper'
+              },
+              {
+                dimensionKey: 'Sub-Category',
+                value: 'Storage'
+              },
+              {
+                dimensionKey: 'Sub-Category',
+                value: 'Supplies'
+              }
+            ]
+          },
+          {
+            dimensionKey: 'Category',
+            value: 'Technology',
+            children: [
+              {
+                dimensionKey: 'Sub-Category',
+                value: 'Accessories'
+              },
+              {
+                dimensionKey: 'Sub-Category',
+                value: 'Copiers'
+              },
+              {
+                dimensionKey: 'Sub-Category',
+                value: 'Machines'
+              },
+              {
+                dimensionKey: 'Sub-Category',
+                value: 'Phones'
+              }
+            ]
+          }
+        ],
+        columnTree: [
+          {
+            dimensionKey: 'Region',
+            value: 'West',
+            children: [
+              {
+                value: 'Sales',
+                indicatorKey: 'Sales'
+              },
+              {
+                value: 'Profit',
+                indicatorKey: 'Profit'
+              }
+            ]
+          },
+          {
+            dimensionKey: 'Region',
+            value: 'South',
+            children: [
+              {
+                value: 'Sales',
+                indicatorKey: 'Sales'
+              },
+              {
+                value: 'Profit',
+                indicatorKey: 'Profit'
+              }
+            ]
+          },
+          {
+            dimensionKey: 'Region',
+            value: 'Central',
+            children: [
+              {
+                value: 'Sales',
+                indicatorKey: 'Sales'
+              },
+              {
+                value: 'Profit',
+                indicatorKey: 'Profit'
+              }
+            ]
+          },
+          {
+            dimensionKey: 'Region',
+            value: 'East',
+            children: [
+              {
+                value: 'Sales',
+                indicatorKey: 'Sales'
+              },
+              {
+                value: 'Profit',
+                indicatorKey: 'Profit'
+              }
+            ]
+          }
+        ],
+        rows: [
+          {
+            dimensionKey: 'Category',
+            title: 'Catogery', // Changed from dimensionTitle to title
+            width: 'auto'
+          },
+          {
+            dimensionKey: 'Sub-Category',
+            title: 'Sub-Catogery', // Changed from dimensionTitle to title
+            width: 'auto'
+          }
+        ],
+        columns: [
+          {
+            dimensionKey: 'Region',
+            title: 'Region', // Changed from dimensionTitle to title
+            headerStyle: {
+              textStick: true
+            },
+            width: 'auto'
+          }
+        ],
+        indicators: [
+          {
+            indicatorKey: 'Sales',
+            title: 'Sales', // Changed from caption to title
+            width: 'auto',
+            showSort: false,
+            headerStyle: {
+              fontWeight: 'normal'
+            },
+            format: value => {
+              if (value != null) {
+                return '$' + Number(value).toFixed(2);
+              }
+              return '';
+            },
+            style: {
+              padding: [16, 28, 16, 28],
+              color(args) {
+                if (args.dataValue >= 0) {
+                  return 'black';
+                }
+                return 'red';
+              }
+            }
+          },
+          {
+            indicatorKey: 'Profit',
+            title: 'Profit', // Changed from caption to title
+            width: 'auto',
+            showSort: false,
+            headerStyle: {
+              fontWeight: 'normal'
+            },
+            format: value => {
+              if (value != null) {
+                return '$' + Number(value).toFixed(2);
+              }
+              return '';
+            },
+            style: {
+              padding: [16, 28, 16, 28],
+              color(args) {
+                if (args.dataValue >= 0) {
+                  return 'black';
+                }
+                return 'red';
+              }
+            }
+          }
+        ],
+        corner: {
+          titleOnDimension: 'row',
+          headerStyle: {
+            textStick: true
+          }
+        },
+        rowHierarchyType: 'tree',
+        widthMode: 'standard',
+        rowHierarchyIndent: 20,
+        rowExpandLevel: 1,
+        dragOrder: {
+          dragHeaderMode: 'all',
+          validateDragOrderOnEnd(source, target) {
+            if (source.row === 3) {
+              return false;
+            }
+            return true;
+          }
+        },
+        rowSeriesNumber: {
+          enable: true,
+          title: '行号',
+          dragOrder: true, // dragOrder for rowSeriesNumber might need specific handling or might not be directly supported in PivotTable in the same way as ListTable.
+          width: 'auto',
+          icon: 'book',
+          headerStyle: {
+            color: 'black',
+            bgColor: 'pink'
+          },
+          style: {
+            color: 'red'
+          }
+        },
+        theme: VTable.themes.BRIGHT // Added a default theme
+      };
+
+      const instance = new PivotTable(option);
+      window.tableInstance = instance;
+      bindDebugTool(instance.scenegraph.stage, { customGrapicKeys: ['col', 'row'] });
+
+      // You might want to add event listeners or other logic here if needed
+    })
+    .catch(error => console.error('Error fetching or processing data:', error));
+}
+
+// To run this example, you would typically call createTable()
+// For example, in your main.ts or an HTML file:
+// document.addEventListener('DOMContentLoaded', createTable);
+// Or if you have a button to trigger it:
+// const button = document.createElement('button');
+// button.innerText = 'Create Pivot Table';
+// button.onclick = createTable;
+// document.body.appendChild(button);
+// Ensure you have a div with id="vTable" in your HTML: <div id="vTable"></div>

--- a/packages/vtable/src/ListTable.ts
+++ b/packages/vtable/src/ListTable.ts
@@ -1557,4 +1557,80 @@ export class ListTable extends BaseTable implements ListTableAPI {
     this.editorManager.release();
     super.release();
   }
+
+  /**
+   * 展开所有树形节点
+   */
+  expandAllTreeNode(): void {
+    let stateChanged = false;
+
+    // 展开所有表头节点
+    const headerObjects = this.internalProps.layoutMap.headerObjects;
+    for (const header of headerObjects) {
+      const headerDefine = header.define as any;
+      if (headerDefine.columns && headerDefine.columns.length > 0) {
+        if (headerDefine.hierarchyState !== HierarchyState.expand) {
+          headerDefine.hierarchyState = HierarchyState.expand;
+          stateChanged = true;
+        }
+      }
+    }
+
+    // 展开所有数据行节点
+    if (this.dataSource && typeof (this.dataSource as any).expandAllNodes === 'function') {
+      (this.dataSource as any).expandAllNodes();
+      stateChanged = true;
+    }
+
+    // 刷新视图
+    if (stateChanged) {
+      this.updateColumns(this.internalProps.columns); // 应用表头变化并重新评估列
+      this.refreshRowColCount(); // 更新行列计数基于数据源变化
+      this.scenegraph.renderSceneGraph(); // 全部重绘
+
+      this.fireListeners(TABLE_EVENT_TYPE.TREE_HIERARCHY_STATE_CHANGE, {
+        col: -1, // 表示非特定单元格操作
+        row: -1,
+        hierarchyState: HierarchyState.expand
+      });
+    }
+  }
+
+  /**
+   * 折叠所有树形节点
+   */
+  collapseAllTreeNode(): void {
+    let stateChanged = false;
+
+    // 折叠所有表头节点
+    const headerObjects = this.internalProps.layoutMap.headerObjects;
+    for (const header of headerObjects) {
+      const headerDefine = header.define as any;
+      if (headerDefine.columns && headerDefine.columns.length > 0) {
+        if (headerDefine.hierarchyState !== HierarchyState.collapse) {
+          headerDefine.hierarchyState = HierarchyState.collapse;
+          stateChanged = true;
+        }
+      }
+    }
+
+    // 折叠所有数据行节点
+    if (this.dataSource && typeof (this.dataSource as any).collapseAllNodes === 'function') {
+      (this.dataSource as any).collapseAllNodes();
+      stateChanged = true;
+    }
+
+    // 刷新视图
+    if (stateChanged) {
+      this.updateColumns(this.internalProps.columns);
+      this.refreshRowColCount();
+      this.scenegraph.renderSceneGraph();
+
+      this.fireListeners(TABLE_EVENT_TYPE.TREE_HIERARCHY_STATE_CHANGE, {
+        col: -1,
+        row: -1,
+        hierarchyState: HierarchyState.collapse
+      });
+    }
+  }
 }

--- a/packages/vtable/src/data/DataSource.ts
+++ b/packages/vtable/src/data/DataSource.ts
@@ -1600,6 +1600,52 @@ export class DataSource extends EventTarget implements DataSourceAPI {
     }
     return childTotalLength;
   }
+
+  private _setNodeStateRecursive(node: any, targetState: HierarchyState): void {
+    if (!node) {
+      return;
+    }
+    const children = (node as any).filteredChildren ?? (node as any).children;
+    // 仅为具有子节点（即可以展开/折叠）的节点设置状态
+    if (children && (Array.isArray(children) ? children.length > 0 : children === true)) {
+      (node as any).hierarchyState = targetState;
+    }
+
+    // 如果子节点作为数组存在，则递归应用于子节点
+    if (children && Array.isArray(children)) {
+      for (const child of children) {
+        this._setNodeStateRecursive(child, targetState);
+      }
+    }
+  }
+
+  expandAllNodes(): void {
+    if (Array.isArray(this._source)) {
+      for (const rootNode of this._source) {
+        this._setNodeStateRecursive(rootNode, HierarchyState.expand);
+      }
+      this.hasHierarchyStateExpand = true;
+      this.clearSortedIndexMap();
+      this.restoreTreeHierarchyState();
+      this.updatePagerData();
+    } else {
+      console.warn('DataSource._source is not an array, cannot expand all nodes.');
+    }
+  }
+
+  collapseAllNodes(): void {
+    if (Array.isArray(this._source)) {
+      for (const rootNode of this._source) {
+        this._setNodeStateRecursive(rootNode, HierarchyState.collapse);
+      }
+      // hasHierarchyStateExpand 将由 restoreTreeHierarchyState 正确更新
+      this.clearSortedIndexMap();
+      this.restoreTreeHierarchyState();
+      this.updatePagerData();
+    } else {
+      console.warn('DataSource._source is not an array, cannot collapse all nodes.');
+    }
+  }
 }
 
 /**

--- a/packages/vtable/src/data/DataSource.ts
+++ b/packages/vtable/src/data/DataSource.ts
@@ -1627,7 +1627,12 @@ export class DataSource extends EventTarget implements DataSourceAPI {
       this.hasHierarchyStateExpand = true;
       this.clearSortedIndexMap();
       this.restoreTreeHierarchyState();
-      this.updatePagerData();
+
+      if (this.lastSortStates && this.lastSortStates.length > 0) {
+        this.sort(this.lastSortStates); // sort 方法内部会调用 updatePagerData
+      } else {
+        this.updatePagerData();
+      }
     } else {
       console.warn('DataSource._source is not an array, cannot expand all nodes.');
     }
@@ -1641,7 +1646,12 @@ export class DataSource extends EventTarget implements DataSourceAPI {
       // hasHierarchyStateExpand 将由 restoreTreeHierarchyState 正确更新
       this.clearSortedIndexMap();
       this.restoreTreeHierarchyState();
-      this.updatePagerData();
+
+      if (this.lastSortStates && this.lastSortStates.length > 0) {
+        this.sort(this.lastSortStates); // sort 方法内部会调用 updatePagerData
+      } else {
+        this.updatePagerData();
+      }
     } else {
       console.warn('DataSource._source is not an array, cannot collapse all nodes.');
     }

--- a/packages/vtable/src/state/cell-move/index.ts
+++ b/packages/vtable/src/state/cell-move/index.ts
@@ -211,8 +211,15 @@ export function endMoveCol(state: StateManager): boolean {
           state.columnMove.rowSource
         )
       ) {
+        const sourceRecordPath = (state.table as ListTable).getRecordIndexByCell(0, moveContext.sourceIndex);
+        const targetRecordPath = (state.table as ListTable).getRecordIndexByCell(0, moveContext.targetIndex);
+
         state.table.changeRecordOrder(moveContext.sourceIndex, moveContext.targetIndex);
-        state.changeCheckboxAndRadioOrder(moveContext.sourceIndex, moveContext.targetIndex);
+
+        // 对于checkbox，使用真实完整的路径
+        state.changeCheckboxOrder(sourceRecordPath, targetRecordPath);
+
+        state.changeRadioOrder(moveContext.sourceIndex, moveContext.targetIndex);
       }
       // clear columns width and rows height cache
       if (moveContext.moveType === 'column') {

--- a/packages/vtable/src/state/cell-move/index.ts
+++ b/packages/vtable/src/state/cell-move/index.ts
@@ -205,14 +205,22 @@ export function endMoveCol(state: StateManager): boolean {
         }
       }
       if (
-        !(state.table as ListTable).transpose &&
+        state.table.isListTable() &&
         (state.table.internalProps.layoutMap as SimpleHeaderLayoutMap).isSeriesNumberInBody(
           state.columnMove.colSource,
           state.columnMove.rowSource
         )
       ) {
-        const sourceRecordPath = (state.table as ListTable).getRecordIndexByCell(0, moveContext.sourceIndex);
-        const targetRecordPath = (state.table as ListTable).getRecordIndexByCell(0, moveContext.targetIndex);
+        let sourceRecordPath;
+        let targetRecordPath;
+
+        if (!(state.table as ListTable).transpose) {
+          sourceRecordPath = (state.table as ListTable).getRecordIndexByCell(0, moveContext.sourceIndex);
+          targetRecordPath = (state.table as ListTable).getRecordIndexByCell(0, moveContext.targetIndex);
+        } else {
+          sourceRecordPath = (state.table as ListTable).getRecordIndexByCell(moveContext.sourceIndex, 0);
+          targetRecordPath = (state.table as ListTable).getRecordIndexByCell(moveContext.targetIndex, 0);
+        }
 
         state.table.changeRecordOrder(moveContext.sourceIndex, moveContext.targetIndex);
 

--- a/packages/vtable/src/state/state.ts
+++ b/packages/vtable/src/state/state.ts
@@ -1769,10 +1769,13 @@ export class StateManager {
     return syncRadioState(col, row, field, radioType, indexInCell, isChecked, this);
   }
 
-  changeCheckboxAndRadioOrder(sourceIndex: number, targetIndex: number) {
+  changeCheckboxOrder(sourceRecordPath: number | number[], targetRecordPath: number | number[]) {
     if (this.checkedState.size) {
-      changeCheckboxOrder(sourceIndex, targetIndex, this);
+      changeCheckboxOrder(sourceRecordPath, targetRecordPath, this);
     }
+  }
+
+  changeRadioOrder(sourceIndex: number, targetIndex: number) {
     if (this.radioState.length) {
       changeRadioOrder(sourceIndex, targetIndex, this);
     }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/VTable/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

relate #3975 

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

##### 🐞问题一（Issue 1）：“刻舟求剑”索引错误
在 checkbox.ts 中，source 和 target 的索引映射是通过 getRecordIndexByCell() 函数，根据 sourceIndex 和 targetIndex 的行号来获取的。

然而该函数内部依赖 _currentPagerIndexedData 进行索引查找，而这个数据已经是拖拽处理之后的结果。

与此同时，sourceIndex 和 targetIndex 依然代表的是拖拽处理前的行号。

因此，source 和 target 的索引映射会出现不一致，导致逻辑错误。

🛠️ 解决方法一

在数据源更新前，提前获取源记录和目标记录的索引信息。

在 endMoveCol 中，在调用 changeRecordOrder 之前，预先通过 getRecordIndexByCell() 获取并保存索引数据，确保索引准确无误。

##### 🐞 问题二（Issue 2）：组间/组内移动未保持 checkbox 状态
当整组（group）移动时，其内部的子项和子孙项未能正确保持其 checkbox 状态。

同样地，组内不同层级的移动，也会出现 checkbox 状态丢失或错乱的情况。

🛠️ 解决方法二

对于组级别的移动：使用 key.startsWith(${sourceIndex}) 来确保组内所有子项同步移动，并保持 checkbox 状态一致。

对于组内任意层级的移动：通过判断路径长度相等且共享相同的父路径，实现对同一层级的识别，并借助 parentPath 维持父级上下文，仅在同一父节点下完成移动。

对于包含嵌套子项的复杂移动：通过前缀匹配策略，使用如下正则精确定位和移动子项：

```ts
new RegExp(`^${parentPath},${i}([,]|$)`)
```

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed incorrect index mapping caused by mismatch between pre-drag and post-drag data; Ensured checkbox states are preserved during group and nested item moves |
| zh Chinese | 修复索引映射错误，避免因拖拽前后数据不一致导致的“刻舟求剑”问题; 支持组及其子项在拖拽移动时保持 checkbox 状态一致性 |


### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
