### PR TITLE
feat(table): support text color customization for selected cells in r…

### DIFF
--- a/packages/vtable/examples/list/list-highlightInRange.ts
+++ b/packages/vtable/examples/list/list-highlightInRange.ts
@@ -234,11 +234,17 @@ export function createTable() {
         borderColor: 'red',
         shadowBlur: 0
       },
+      selectionStyle: {
+        selectionFillMode: 'replace'
+      },
       bodyStyle: {
         select: {
           cellBgColor: 'red',
           inlineRowBgColor: 'pink',
-          inlineColumnBgColor: 'purple'
+          inlineColumnBgColor: 'purple',
+          cellTextColor: 'white',
+          inlineRowTextColor: 'white',
+          inlineColumnTextColor: 'white'
         }
       }
     },

--- a/packages/vtable/src/scenegraph/graphic/contributions/index.ts
+++ b/packages/vtable/src/scenegraph/graphic/contributions/index.ts
@@ -34,7 +34,11 @@ import {
   // ClipBodyGroupAfterRenderContribution
 } from './group-contribution-render';
 import { VTableDrawItemInterceptorContribution } from './draw-interceptor';
-import { SuffixTextBeforeRenderContribution } from './text-contribution-render';
+import {
+  SuffixTextBeforeRenderContribution,
+  SelectedCellTextColorBeforeRenderContribution,
+  SelectedCellTextColorAfterRenderContribution
+} from './text-contribution-render';
 import { VChartPicker } from './vchart-graphic-picker';
 // import { VChartPickServiceInterceptorContribution } from './picker-interceptor';
 
@@ -107,4 +111,9 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
   // text 渲染器注入contributions
   bind(SuffixTextBeforeRenderContribution).toSelf().inSingletonScope();
   bind(TextRenderContribution).toService(SuffixTextBeforeRenderContribution);
+
+  bind(SelectedCellTextColorBeforeRenderContribution).toSelf().inSingletonScope();
+  bind(TextRenderContribution).toService(SelectedCellTextColorBeforeRenderContribution);
+  bind(SelectedCellTextColorAfterRenderContribution).toSelf().inSingletonScope();
+  bind(TextRenderContribution).toService(SelectedCellTextColorAfterRenderContribution);
 });

--- a/packages/vtable/src/state/select/is-cell-select-highlight.ts
+++ b/packages/vtable/src/state/select/is-cell-select-highlight.ts
@@ -56,6 +56,31 @@ export function getCellSelectColor(cellGroup: Group, table: BaseTableAPI): strin
   const fillColor = getProp(colorKey, selectStyle, cellGroup.col, cellGroup.row, table);
   return fillColor;
 }
+/**
+ * 获取选中单元格的文本颜色
+ */
+export function getSelectedCellTextColor(cellGroup: Group, table: BaseTableAPI): string | undefined {
+  const styleKey = getCellTypeSelectionStyleKey(table.stateManager, cellGroup.col, cellGroup.row);
+  if (!styleKey) {
+    return undefined;
+  }
+  let selectStyle;
+  const layout = table.internalProps.layoutMap;
+  const col = cellGroup.col;
+  const row = cellGroup.row;
+  if (
+    !layout.isCornerHeader(col, row) &&
+    !layout.isColumnHeader(col, row) &&
+    !layout.isRowHeader(col, row) &&
+    !layout.isBottomFrozenRow(col, row) &&
+    !layout.isRightFrozenColumn(col, row) &&
+    !table.isHeader(col, row)
+  ) {
+    selectStyle = table.theme.bodyStyle?.select;
+  }
+  const textColor = getProp(styleKey, selectStyle, col, row, table);
+  return textColor;
+}
 
 // 选中多列
 function isSelectMultipleRange(range: CellRange) {
@@ -164,6 +189,30 @@ export function isCellSelected(state: StateManager, col: number, row: number, ce
     }
   }
   return selectMode;
+}
+/**
+ * 获取不同类型单元格的选择样式键名
+ * 复用了isCellSelected的逻辑，根据单元格位置返回对应的样式属性名：
+ * - 当前选中单元格：'cellTextColor'
+ * - 同行单元格：'inlineRowTextColor'
+ * - 同列单元格：'inlineColumnTextColor'
+ */
+export function getCellTypeSelectionStyleKey(
+  state: StateManager,
+  col: number,
+  row: number
+): 'cellTextColor' | 'inlineRowTextColor' | 'inlineColumnTextColor' | undefined {
+  const selectMode = isCellSelected(state, col, row, null);
+  switch (selectMode) {
+    case 'cellBgColor':
+      return 'cellTextColor';
+    case 'inlineRowBgColor':
+      return 'inlineRowTextColor';
+    case 'inlineColumnBgColor':
+      return 'inlineColumnTextColor';
+    default:
+      return undefined;
+  }
 }
 /**
  * 判断单元格是否禁用选择。先判断高优配置select.disableSelect。

--- a/packages/vtable/src/themes/theme-define.ts
+++ b/packages/vtable/src/themes/theme-define.ts
@@ -47,6 +47,7 @@ import {
   DEFAULTFONTSIZE
 } from '../tools/global';
 import { defalutPoptipStyle, getAxisStyle } from './component';
+import type { BodyThemeStyle } from '../ts-types/theme';
 //private symbol
 // const _ = getSymbol();
 
@@ -927,6 +928,15 @@ export class TableTheme implements ITableThemeDefine {
               return style.select?.cellBgColor ?? that.selectionStyle.cellBgColor ?? undefined;
             }
             return undefined;
+          },
+          get cellTextColor(): ColorPropertyDefine | undefined {
+            return (style as BodyThemeStyle).select?.cellTextColor ?? undefined;
+          },
+          get inlineRowTextColor(): ColorPropertyDefine | undefined {
+            return (style as BodyThemeStyle).select?.inlineRowTextColor ?? undefined;
+          },
+          get inlineColumnTextColor(): ColorPropertyDefine | undefined {
+            return (style as BodyThemeStyle).select?.inlineColumnTextColor ?? undefined;
           }
         };
         // }

--- a/packages/vtable/src/ts-types/theme.ts
+++ b/packages/vtable/src/ts-types/theme.ts
@@ -25,6 +25,9 @@ export type InteractionStyle = {
   // inlineColBorderColor?: ColorsPropertyDefine,//交互所在整列的边框颜色
   inlineColumnBgColor?: ColorPropertyDefine; //交互所在整列的背景颜色
   // headerHighlightBorderColor?:ColorPropertyDefine,//表头底部高亮线
+  cellTextColor?: ColorPropertyDefine; //交互所在单元格的文本颜色
+  inlineRowTextColor?: ColorPropertyDefine; //交互所在整行的文本颜色
+  inlineColumnTextColor?: ColorPropertyDefine; //交互所在整列的文本颜色
 };
 export type FrameStyle = {
   borderColor?: ColorsDef;
@@ -86,6 +89,14 @@ export type TooltipStyle = {
   /**气泡框位置，可选 top left right bottom */
   // placement?: Placement;
 };
+
+export type BodyThemeStyle = ThemeStyle & {
+  select?: {
+    cellTextColor?: ColorPropertyDefine; //交互所在单元格的文本颜色
+    inlineRowTextColor?: ColorPropertyDefine; //交互所在整行的文本颜色
+    inlineColumnTextColor?: ColorPropertyDefine; //交互所在整列的文本颜色
+  };
+};
 export interface ITableThemeDefine {
   /** 表格绘制范围外的canvas上填充的颜色 */
   underlayBackgroundColor?: string;
@@ -99,7 +110,7 @@ export interface ITableThemeDefine {
   bottomFrozenStyle?: ThemeStyle; // 下部冻结单元格样式
   headerStyle?: ThemeStyle;
   rowHeaderStyle?: ThemeStyle;
-  bodyStyle?: ThemeStyle;
+  bodyStyle?: BodyThemeStyle;
   groupTitleStyle?: ThemeStyle;
   frameStyle?: TableFrameStyle;
   //列调整宽度的直线


### PR DESCRIPTION
…eplace mode

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/VTable/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [✅] New feature
- [ ] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link
https://github.com/VisActor/VTable/issues/3993
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

在replace模式下，选区背景颜色过深可能会使文本看不清，该feature允许对选区内的文本颜色进行设置。

```
    theme: {
      bodyStyle: {
        select: {
          cellTextColor: 'white', // 选区文本颜色
          inlineRowTextColor: 'blue', // 选中行文本颜色
          inlineColumnTextColor: 'red' // 选中列文本颜色
        }
      },

      selectionStyle: {
        cellBorderLineWidth: 2,
        cellBorderColor: 'blue',
        cellBgColor: 'rgba(27, 38, 46, 0.6)',
        selectionFillMode: 'replace'
      }
    }
```

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->
文本颜色展示的逻辑尽可能地复用了replace模式对选区单元格填充的逻辑，以避免文本颜色填充与单元格背景颜色填充不一致的情况。
| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    support text color customization for selected cells in replace mode       |
| 🇨🇳 Chinese |      在填充模式为replace模式下，bodyStyle属性可以设置选区内单元格文本颜色     |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [✅] Demo is updated/provided or not needed
- [✅] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
