### PR TITLE
fix(gantt): avoid row calculation errors when children is empty array

### DIFF
--- a/packages/vtable-gantt/src/gantt-helper.ts
+++ b/packages/vtable-gantt/src/gantt-helper.ts
@@ -912,7 +912,7 @@ export function getTaskIndexsByTaskY(y: number, gantt: Gantt) {
 }
 
 export function computeRowsCountByRecordDateForCompact(gantt: Gantt, record: any) {
-  if (!record.children || record.children.length === 1) {
+  if (!record.children || record.children.length <= 1) {
     if (record.children?.length === 1) {
       record.children[0].vtable_gantt_showIndex = 0;
     } else {
@@ -962,7 +962,7 @@ function isOverlapping(startDate: Date, endDate: Date, rowTasks: any[], gantt: G
   });
 }
 export function computeRowsCountByRecordDate(gantt: Gantt, record: any) {
-  if (!record.children || record.children.length === 1) {
+  if (!record.children || record.children.length <= 1) {
     if (record.children?.length === 1) {
       record.children[0].vtable_gantt_showIndex = 0;
     } else {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/VTable/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [✅] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link
https://github.com/VisActor/VTable/issues/4035
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
在Arrange和Compact模式下，如果记录的子任务列表为空数组，会出现任务条错位，单元格边框消失，行消失的情况。这是因为在计算行数的时候忽略了空数组的情况

https://jsfiddle.net/t3v0uw6x/

![ba3fd8f91b6686b3f9a1412a7c6baf26](https://github.com/user-attachments/assets/36e259de-831a-4db0-94a9-041c90107277)


```
export function computeRowsCountByRecordDate(gantt: Gantt, record: any) {
// 忽略了空数组的情况
  if (!record.children || record.children.length === 1) {
    if (record.children?.length === 1) {
      record.children[0].vtable_gantt_showIndex = 0;
    } else {
      record.vtable_gantt_showIndex = 0;
    }
    return 1;
  }
 
...
 return rows.length; //最后返回值为0

```



<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      In Arrange/Compact modes, empty subtask arrays in records cause row calculation errors.     |
| 🇨🇳 Chinese |    在Arrange和Compact模式下，记录的子任务列表为空数组会导致行计算错误       |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
