### PR TITLE
fix: 修复透视表多列树形表格行表头收起再重新展开后,getCellAddressByHeaderPaths方法获取行号不正确的问题

### DIFF
--- a/packages/vtable/examples/menu.ts
+++ b/packages/vtable/examples/menu.ts
@@ -555,6 +555,10 @@ export const menus = [
       },
       {
         path: 'pivot',
+        name: 'pivot-extension-row3'
+      },
+      {
+        path: 'pivot',
         name: 'pivot-extension-bp'
       },
       {

--- a/packages/vtable/examples/pivot/pivot-extension-row3.ts
+++ b/packages/vtable/examples/pivot/pivot-extension-row3.ts
@@ -1,0 +1,160 @@
+import * as VTable from '../../src';
+import { bindDebugTool } from '../../src/scenegraph/debug-tool';
+const PivotTable = VTable.PivotTable;
+const CONTAINER_ID = 'vTable';
+
+export function createTable() {
+  const option = {
+    records: [],
+    rows: [
+      {
+        dimensionKey: 'DATA_TYPE',
+        title: '数据类型',
+        width: 'auto',
+        minWidth: 100,
+        sort: true,
+        showSort: false,
+        showSortInCorner: false,
+        headerStyle: {
+          textStick: false,
+          fontSize: 12,
+          color: 'rgba(17, 25, 37, 0.85)'
+        }
+      }
+    ],
+    rowTree: [
+      {
+        dimensionKey: 'DATA_TYPE',
+        value: '测试1'
+      },
+      {
+        dimensionKey: 'DATA_TYPE',
+        value: '测试2'
+      }
+    ],
+    extensionRows: [
+      {
+        rows: [
+          {
+            dimensionKey: 'dim_0f3fd7af',
+            title: 'test1/test2',
+            width: 'auto',
+            minWidth: 100,
+            sort: true,
+            showSort: false,
+            showSortInCorner: false,
+            headerStyle: {
+              textStick: false,
+              fontSize: 12,
+              color: 'rgba(17, 25, 37, 0.85)'
+            }
+          },
+          {
+            dimensionKey: 'dim_6dd5f4b5',
+            title: 'test2',
+            width: 'auto',
+            minWidth: 100,
+            sort: true,
+            showSort: false,
+            showSortInCorner: false,
+            headerStyle: {
+              textStick: false,
+              fontSize: 12,
+              color: 'rgba(17, 25, 37, 0.85)'
+            }
+          }
+        ],
+        rowTree: [
+          {
+            dimensionKey: 'dim_0f3fd7af',
+            value: 'value1',
+            children: [
+              {
+                dimensionKey: 'dim_6dd5f4b5',
+                value: 'value1-1',
+                children: [],
+                hierarchyState: 'expand'
+              },
+              {
+                dimensionKey: 'dim_6dd5f4b5',
+                value: 'value1-2',
+                children: [],
+                hierarchyState: 'expand'
+              },
+              {
+                dimensionKey: 'dim_6dd5f4b5',
+                value: 'value1-3',
+                children: [],
+                hierarchyState: 'expand'
+              }
+            ],
+            hierarchyState: 'expand'
+          },
+          {
+            dimensionKey: 'dim_0f3fd7af',
+            value: 'value2',
+            children: [
+              {
+                dimensionKey: 'dim_6dd5f4b5',
+                value: 'value2-1',
+                children: [],
+                hierarchyState: 'expand'
+              }
+            ],
+            hierarchyState: 'expand'
+          },
+
+          {
+            dimensionKey: 'dim_0f3fd7af',
+            value: '列小计',
+            children: []
+          }
+        ]
+      }
+    ],
+    indicators: [
+      {
+        indicatorKey: 'DATE_DIM_0_0',
+        title: '2025-03',
+        width: 'auto',
+        sort: true,
+        showSort: true,
+        headerStyle: {
+          fontWeight: 'normal',
+          color: 'rgba(17, 25, 37, 0.85)'
+        },
+        style: {
+          textAlign: 'right',
+          padding: [8, 12, 8, 12],
+          fontSize: 12
+        }
+      }
+    ],
+    frozenColCount: 3,
+    rowExpandLevel: null,
+    rowHierarchyType: 'tree',
+    rowHierarchyIndent: 12,
+    rowHierarchyTextStartAlignment: true,
+    defaultRowHeight: 28,
+    defaultHeaderRowHeight: 34,
+    autoFillWidth: true
+  };
+
+  const instance = new PivotTable(document.getElementById(CONTAINER_ID)!, option);
+
+  instance.on('click_cell', params => {
+    console.log(
+      'params',
+      params,
+      instance.getCellHeaderPaths(params.col, params.row),
+      instance.getCellAddressByHeaderPaths({
+        colHeaderPaths: params.cellHeaderPaths.colHeaderPaths,
+        rowHeaderPaths: params.cellHeaderPaths.rowHeaderPaths
+      })
+    );
+  });
+
+  window.tableInstance = instance;
+
+  bindDebugTool(instance.scenegraph.stage, { customGrapicKeys: ['col', 'row'] });
+}

--- a/packages/vtable/src/layout/pivot-header-layout.ts
+++ b/packages/vtable/src/layout/pivot-header-layout.ts
@@ -2432,7 +2432,17 @@ export class PivotHeaderLayoutMap implements LayoutMapAPI {
     this.rowDimensionKeys = this.rowDimensionTree.dimensionKeysIncludeVirtual.valueArr();
     this.fullRowDimensionKeys = [];
     this.fullRowDimensionKeys = this.fullRowDimensionKeys.concat(this.rowDimensionKeys);
+
     if (this.rowHierarchyType === 'tree') {
+      // 确保extensionRows的维度键也被包含在fullRowDimensionKeys中
+      if (this.extensionRows?.length > 0) {
+        this.extensionRows.forEach(extensionRow => {
+          const extensionRowDimensionKeys =
+            extensionRow.rows?.map(row => (typeof row === 'string' ? row : row.dimensionKey)) || [];
+          this.fullRowDimensionKeys = this.fullRowDimensionKeys.concat(extensionRowDimensionKeys);
+        });
+      }
+
       this._addHeadersForTreeMode(
         this._rowHeaderCellFullPathIds_FULL,
         0,


### PR DESCRIPTION
### 🤔 这个分支是...

- [✅] Bug fix

### 🔗 相关 issue 连接

https://github.com/VisActor/VTable/issues/4037#issuecomment-2969734677

### 💡 问题的背景&解决方案

#### 问题背景

使用透视表构建多列树形表格，使用getCellAddressByHeaderPaths方法获取单元格行号时。在未对表格扩展行做展开收起操作时能够通过该api获取到正确行号，但一旦对属性表格做了收起操作，即使再重新展开对应单元格，调用该API获取的任意单元格行号都为0。

#### 问题排查 & 解决方案

阅读源码排查发现，是因为packages/vtable/src/layout/pivot-header-layout.ts中，只在初始化构建的时候，为fullRowDimensionKeys添加了extensionRow的扩展行key，展开收起操作会对重置fullRowDimensionKeys为空数组，且没有再重新添加extensionRow，这使得内部存储的headerPath不包含扩展行的key，导致和输入的单元格headerPath匹配不上。因此需要在展开收起事件的回调函数中补充添加extensionRow的逻辑。

<img width="993" alt="image" src="https://github.com/user-attachments/assets/9c975af7-2798-42e1-926e-8be5c2bbb22d" />

<img width="1091" alt="image" src="https://github.com/user-attachments/assets/ac8791f1-b2b5-428f-bfa8-1a0fc17f6cc6" />


### 📝 Changelog

在展开收起事件的回调函数中为fullRowDimensionKeys补充添加了extensionRowKey的逻辑。

### ☑️ 自测

⚠️ 在提交 PR 之前，请检查一下内容. ⚠️

[✅] 添加了新的测试demo（packages/vtable/examples/pivot/pivot-extension-row3.ts），在这个demo中测试，添加代码前，展开收起再展开调用api获取的row永远是0，添加代码后，调用api获取的行号正确。


<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough