### PR TITLE
fix: group by boolean cannot render false

### DIFF
--- a/packages/vtable/src/scenegraph/group-creater/cell-helper.ts
+++ b/packages/vtable/src/scenegraph/group-creater/cell-helper.ts
@@ -665,7 +665,7 @@ export function updateCell(
       }
       if ((table.options as ListTableConstructorOptions).groupTitleFieldFormat) {
         value = (table.options as ListTableConstructorOptions).groupTitleFieldFormat(rawRecord, col, row, table);
-      } else if (vtableMergeName) {
+      } else if (vtableMergeName !== undefined) {
         value = vtableMergeName;
       }
     }
@@ -788,8 +788,8 @@ export function updateCell(
     isVtableMerge || isCustomMerge
       ? 'text'
       : table.isHeader(col, row)
-      ? (table._getHeaderLayoutMap(col, row) as HeaderData).headerType ?? 'text'
-      : table.getBodyColumnType(col, row) ?? 'text';
+        ? ((table._getHeaderLayoutMap(col, row) as HeaderData).headerType ?? 'text')
+        : (table.getBodyColumnType(col, row) ?? 'text');
 
   const padding = cellTheme._vtable.padding;
   const textAlign = cellTheme.text.textAlign;
@@ -1192,8 +1192,8 @@ export function resizeCellGroup(
       });
       child.skipMergeUpdate = false;
     } else {
-      child.skipMergeUpdate = true;
       child._dx = child.attribute.dx ?? 0;
+      child.skipMergeUpdate = true;
       child.setAttributes({
         dx: (child.attribute.dx ?? 0) + dx
       });

--- a/packages/vtable/src/scenegraph/group-creater/column-helper.ts
+++ b/packages/vtable/src/scenegraph/group-creater/column-helper.ts
@@ -190,7 +190,7 @@ export function createComplexColumn(
         }
         if ((table.options as ListTableConstructorOptions).groupTitleFieldFormat) {
           value = (table.options as ListTableConstructorOptions).groupTitleFieldFormat(rawRecord, col, row, table);
-        } else if (vtableMergeName) {
+        } else if (vtableMergeName !== undefined) {
           value = vtableMergeName;
         }
       }
@@ -199,9 +199,9 @@ export function createComplexColumn(
     const type =
       isVtableMerge || isCustomMerge
         ? 'text'
-        : (table.isHeader(col, row)
-            ? (table._getHeaderLayoutMap(col, row) as HeaderData).headerType ?? 'text'
-            : table.getBodyColumnType(col, row)) ?? 'text';
+        : ((table.isHeader(col, row)
+            ? ((table._getHeaderLayoutMap(col, row) as HeaderData).headerType ?? 'text')
+            : table.getBodyColumnType(col, row)) ?? 'text');
 
     // deal with promise data
     if (isPromise(value)) {


### PR DESCRIPTION
### 🤔 这个分支是...

- [ ✅ ] Bug fix

### 🔗 相关 issue 连接
[#4059 ](https://github.com/VisActor/VTable/issues/4059)

### 💡 问题的背景&解决方案

#### 问题背景
当使用 groupBy 属性根据 boolean 值分类时，false 值的分组标题不显示，而 true 值的分组标题正常显示。

#### 问题排查
代码中使用了 if (vtableMergeName) 判断，当 vtableMergeName 为 false 时，这个条件会被认为是 falsy，所以不会执行 value = vtableMergeName;这行代码，导致分组标题不显示。

#### 解决方案
将判断条件细化为if (vtableMergeName !== undefined)，这样修改后，无论 vtableMergeName 是 true、false、0、空字符串还是其他 falsy 值，只要它不是 undefined，就会正确显示分组标题。

### 📝 Changelog

<!--
描述用户侧的修改，并列出所有可能的新功能、修改、以及风险
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |      当使用 groupBy 属性根据 boolean 值分类时，false 值的分组标题也可以正常显示     |

### ☑️ 自测

⚠️ 在提交 PR 之前，请检查一下内容. ⚠️

- [ ] 文档提供了，或者更新，或者不需要
- [ ] Demo 提供了，或者更新，或者不需要
- [ ] Ts 类型定义提供了，或者更新，或者不需要
- [ ] Changelog 提供了，或者不需要

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough