### PR TITLE
fix:header-description error

### DIFF
--- a/packages/vtable/examples/list/list-header-levelSpan.ts
+++ b/packages/vtable/examples/list/list-header-levelSpan.ts
@@ -102,13 +102,15 @@ export function createTable() {
             {
               field: 'field11',
               caption: 'field11',
+              description: 'field11',
               // title: 'field11',
               width: '150',
               columns: [
                 {
                   field: 'math',
                   title: 'math',
-                  width: '150'
+                  width: '150',
+                  description: 'math'
                 }
               ]
             },

--- a/packages/vtable/src/layout/simple-header-layout.ts
+++ b/packages/vtable/src/layout/simple-header-layout.ts
@@ -1022,7 +1022,7 @@ export class SimpleHeaderLayoutMap implements LayoutMapAPI {
         // iconPositionList:[]
       };
       results[id] = cell;
-      //处理levelSpan 跨行处理
+      // 处理levelSpan 跨行处理
       let maxRow = row;
       if (hd.levelSpan) {
         maxRow = Math.min(row + hd.levelSpan - 1, this._columnMaxDepth - 1);
@@ -1076,7 +1076,7 @@ export class SimpleHeaderLayoutMap implements LayoutMapAPI {
           ).forEach(c => results.push(c));
       } else {
         const colDef = {
-          id: id,
+          id: this.seqId++,
           field: hd.field,
           // fieldKey: colDef.fieldKey,
           fieldFormat: hd.fieldFormat,


### PR DESCRIPTION
🤔 这个分支是 Bug fix
🔗 相关 issue 连接
[#3555 ](https://github.com/VisActor/VTable/issues/3555)

💡 问题的背景&解决方案
id赋值给表头单元格逻辑导致最深度header的description会在表格内容里显示
将colDef中id赋值改回this.seqId++

☑️ 自测
🚀 Summary
本次提交修复了id赋值给表头单元格逻辑导致最深度header的description会在表格内容里显示的问题