### PR TITLE
fix: paste validateValue missing position table params

### DIFF
--- a/packages/vtable/src/core/record-helper.ts
+++ b/packages/vtable/src/core/record-helper.ts
@@ -172,7 +172,8 @@ export function listTableChangeCellValues(
           const editor = table.getEditor(startCol + j, startRow + i);
           const oldValue = oldValues[i][j];
           const value = rowValues[j];
-          const maybePromiseOrValue = editor?.validateValue?.(value, oldValue) ?? true;
+          const maybePromiseOrValue =
+            editor?.validateValue?.(value, oldValue, { col: startCol + j, row: startRow + i }, table) ?? true;
           if (isPromise(maybePromiseOrValue)) {
             //TODO 处理promise的情况
             isCanChange = true;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/VTable/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link

关闭 https://github.com/VisActor/VTable/issues/4163
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

当使用粘贴的方式设置单元格时，自定义编辑器的validateValue无法获取到position和table参数 ，从而无法验证当前复制的单元格是否允许编辑等相关信息，导致使用上的不便。

### 📝 Changelog

通过粘贴的方式设置单元格内容，自定义的编辑器validateValue验证函数，可以对单元格是否允许编辑等情况进行验证。

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
