### PR TITLE
fix: paste isCanchange validate logic

### DIFF
--- a/packages/vtable/src/core/record-helper.ts
+++ b/packages/vtable/src/core/record-helper.ts
@@ -180,7 +180,7 @@ export function listTableChangeCellValues(
             isCanChange =
               maybePromiseOrValue === true ||
               maybePromiseOrValue === 'validate-exit' ||
-              maybePromiseOrValue === 'invalidate-exit';
+              maybePromiseOrValue === 'validate-not-exit';
           }
         }
       }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/VTable/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [X] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link

close https://github.com/VisActor/VTable/issues/4174

### 💡 Background and solution

如果自定义了编辑器用于验证数据，当粘贴数据时，如果非法数据返回 invalidate-exit，那么同样会修改单元格的值，问题在于packages\vtable\src\core\record-helper.ts 180行处，把验证逻辑填错了一个单词。修改成validate-not-exit就能解决这个问题了

### 📝 Changelog

修复验证逻辑

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [X] Doc is updated/provided or not needed
- [X] Demo is updated/provided or not needed
- [X] TypeScript definition is updated/provided or not needed
- [X] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
