### PR TITLE
树形表单的时候，在不展开树形时，无法通过search组件搜索内容。

### DIFF
--- a/packages/vtable-search/src/search-component/search-component.ts
+++ b/packages/vtable-search/src/search-component/search-component.ts
@@ -65,7 +65,7 @@ export class SearchComponent {
     this.table.registerCustomCellStyle('__search_component_focuse', this.focuseHighlightCellStyle as any);
   }
 
-  search(str: string) {
+   search(str: string) {
     this.clear();
     this.queryStr = str;
 
@@ -75,6 +75,46 @@ export class SearchComponent {
         results: this.queryResult
       };
     }
+
+    // 递归搜索并展开匹配节点的父级路径
+    function findAndExpandMatches(records, path = []) {
+      let hasMatch = false;
+
+      records.forEach(record => {
+        const currentPath = [...path, record];
+        let shouldExpand = false;
+
+        // 检查当前节点是否匹配
+        if (this.queryMethod(this.queryStr, record.value || record, {})) {
+          shouldExpand = true;
+          hasMatch = true;
+        }
+
+        // 递归检查子节点
+        if (record.children && record.children.length > 0) {
+          const childHasMatch = findAndExpandMatches(record.children, currentPath);
+          if (childHasMatch) {
+            shouldExpand = true;
+            hasMatch = true;
+          }
+        }
+
+        // 如果当前节点或其子节点有匹配，展开整个路径
+        if (shouldExpand) {
+          currentPath.forEach(node => {
+            node.hierarchyState = 'expand';
+          });
+        }
+      });
+
+      return hasMatch;
+    }
+
+    const records = this.table.records;
+    const hasMatches = findAndExpandMatches.call(this, records);
+    this.table.setRecords(records);
+
+    
 
     for (let row = 0; row < this.table.rowCount; row++) {
       for (let col = 0; col < this.table.colCount; col++) {


### PR DESCRIPTION

<!--
原因是search是根据渲染出来的row和col进行查询，但树形未展开的时候并未渲染。
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/VTable/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [* ] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
