### PR TITLE
feat: add progress adjustment feature for task bars

### DIFF
--- a/docs/assets/option/en/common/gantt/task-bar.md
+++ b/docs/assets/option/en/common/gantt/task-bar.md
@@ -52,7 +52,6 @@ export type TaskBarInteractionArgumentType = {
 };
 ```
 
-
 {{ use: common-gantt-task-bar-style }}
 
 ${prefix} milestoneStyle(ITaskBarStyle)
@@ -110,6 +109,26 @@ export type TaskBarInteractionArgumentType = {
   ganttInstance: Gantt;
 };
 ```
+
+${prefix} progressAdjustable(boolean | Function) = true
+
+Whether the task progress can be adjusted. The default is true. When set to true, users can drag the progress handle on the task bar to adjust the progress percentage. When set to false, the progress handle will be hidden and progress adjustment is disabled.
+
+Optional
+
+```
+progressAdjustable?: boolean | ((interactionArgs: TaskBarInteractionArgumentType) => boolean);
+
+export type TaskBarInteractionArgumentType = {
+  taskRecord: any;
+  index: number;
+  startDate: Date;
+  endDate: Date;
+  ganttInstance: Gantt;
+};
+```
+
+**Note:** Progress adjustment is only available when the task has a progress field defined. Milestone tasks cannot have their progress adjusted.
 
 ${prefix} moveToExtendDateRange(boolean) = true
 

--- a/docs/assets/option/zh/common/gantt/task-bar.md
+++ b/docs/assets/option/zh/common/gantt/task-bar.md
@@ -114,6 +114,27 @@ export type TaskBarInteractionArgumentType = {
 };
 ```
 
+${prefix} progressAdjustable(boolean | Function) = true
+
+任务进度是否可调整。默认为 true。设置为 true 时，用户可以拖拽任务条上的进度控制柄来调整进度百分比。设置为 false 时，进度控制柄将被隐藏，禁止进度调整。
+
+非必填
+
+```
+progressAdjustable?: boolean | ((interactionArgs: TaskBarInteractionArgumentType) => boolean);
+
+//其中：
+export type TaskBarInteractionArgumentType = {
+  taskRecord: any;
+  index: number;
+  startDate: Date;
+  endDate: Date;
+  ganttInstance: Gantt;
+};
+```
+
+**注意：** 只有当任务定义了进度字段时，进度调整功能才可用。里程碑任务无法调整进度。
+
 ${prefix} moveToExtendDateRange(boolean) = true
 
 任务条拖拽超出当前日期范围时自动扩展日期范围, 默认为 true

--- a/packages/vtable-gantt/src/Gantt.ts
+++ b/packages/vtable-gantt/src/Gantt.ts
@@ -147,6 +147,7 @@ export class Gantt extends EventTarget {
       | boolean
       | [boolean, boolean]
       | ((interactionArgs: TaskBarInteractionArgumentType) => boolean | [boolean, boolean]);
+    taskBarProgressAdjustable: boolean | ((interactionArgs: TaskBarInteractionArgumentType) => boolean);
     taskBarDragOrder: boolean;
     taskBarLabelStyle: ITaskBarLabelTextStyle;
     taskBarCustomLayout: ITaskBarCustomLayout;
@@ -964,6 +965,20 @@ export class Gantt extends EventTarget {
     } else if (Array.isArray(sub_task_index)) {
       // 递归更新父级project任务的时间范围
       this.stateManager.updateProjectTaskTimes(sub_task_index);
+    }
+  }
+
+  /**
+   * 更新任务进度
+   * @param progress 进度
+   * @param index 对应的一定是左侧表格body的index
+   * @param sub_task_index 子任务的index, 当taskShowMode是sub_tasks_*模式时，会传入sub_task_index。如果是tasks_separate模式，sub_task_index传入undefined。
+   */
+  _updateProgressToTaskRecord(progress: number, index: number, sub_task_index?: number) {
+    const taskRecord = this.getRecordByIndex(index, sub_task_index);
+    const progressField = this.parsedOptions.progressField;
+    if (progressField) {
+      taskRecord[progressField] = progress;
     }
   }
 

--- a/packages/vtable-gantt/src/gantt-helper.ts
+++ b/packages/vtable-gantt/src/gantt-helper.ts
@@ -272,6 +272,7 @@ export function initOptions(gantt: Gantt) {
   gantt.parsedOptions.taskBarMoveable = options?.taskBar?.moveable ?? true;
   gantt.parsedOptions.moveTaskBarToExtendDateRange = options?.taskBar?.moveToExtendDateRange ?? true;
   gantt.parsedOptions.taskBarResizable = options?.taskBar?.resizable ?? true;
+  gantt.parsedOptions.taskBarProgressAdjustable = options?.taskBar?.progressAdjustable ?? true;
   gantt.parsedOptions.taskBarDragOrder = options?.taskBar?.dragOrder ?? true;
 
   // gantt.parsedOptions.taskBarHoverColor =

--- a/packages/vtable-gantt/src/state/state-manager.ts
+++ b/packages/vtable-gantt/src/state/state-manager.ts
@@ -1,8 +1,8 @@
-import { clone, cloneDeep, isValid, max } from '@visactor/vutils';
+import { isValid } from '@visactor/vutils';
 import type { Gantt } from '../Gantt';
 import type { ITaskLink } from '../ts-types';
 import { InteractionState, GANTT_EVENT_TYPE, DependencyType, TasksShowMode, TaskType } from '../ts-types';
-import type { Group, FederatedPointerEvent, Polygon, Line, Circle } from '@visactor/vtable/es/vrender';
+import type { Group, FederatedPointerEvent, Polygon, Line } from '@visactor/vtable/es/vrender';
 import {
   syncEditCellFromTable,
   syncScrollStateFromTable,
@@ -23,7 +23,13 @@ import { debounce } from '../tools/debounce';
 import type { GanttTaskBarNode } from '../scenegraph/gantt-node';
 import { TASKBAR_HOVER_ICON_WIDTH } from '../scenegraph/task-bar';
 import { Inertia } from '../tools/inertia';
-import { createDateAtMidnight, getEndDateByTimeUnit, getStartDateByTimeUnit, toBoxArray } from '../tools/util';
+import {
+  createDateAtMidnight,
+  getEndDateByTimeUnit,
+  getStartDateByTimeUnit,
+  toBoxArray,
+  parseStringTemplate
+} from '../tools/util';
 export class StateManager {
   _gantt: Gantt;
 
@@ -74,6 +80,14 @@ export class StateManager {
     target: GanttTaskBarNode;
     resizing: boolean;
     onIconName: string;
+  };
+  adjustProgressBar: {
+    /** x坐标是相对table内坐标 */
+    startX: number;
+    startY: number;
+    target: GanttTaskBarNode;
+    adjusting: boolean;
+    originalProgress: number;
   };
   selectedTaskBar: {
     target: GanttTaskBarNode;
@@ -148,6 +162,13 @@ export class StateManager {
       target: null,
       resizing: false,
       onIconName: ''
+    };
+    this.adjustProgressBar = {
+      startX: null,
+      startY: null,
+      target: null,
+      adjusting: false,
+      originalProgress: 0
     };
     this.resizeTableWidth = {
       lastX: null,
@@ -790,6 +811,92 @@ export class StateManager {
     );
 
     this._gantt.scenegraph.updateNextFrame();
+  }
+  startAdjustProgressBar(target: GanttTaskBarNode, x: number, y: number) {
+    const { progress } = this._gantt.getTaskInfoByTaskListIndex(target.task_index, target.sub_task_index);
+    this.adjustProgressBar.target = target;
+    this.adjustProgressBar.adjusting = true;
+    this.adjustProgressBar.startX = x;
+    this.adjustProgressBar.startY = y;
+    this.adjustProgressBar.originalProgress = progress;
+  }
+  isAdjustingProgressBar() {
+    return this.adjustProgressBar.adjusting;
+  }
+  endAdjustProgressBar(x: number) {
+    const target = this.adjustProgressBar.target;
+    const taskBarWidth = target.attribute.width;
+    const deltaX = x - this.adjustProgressBar.startX;
+    const newProgress = Math.max(
+      0,
+      Math.min(100, this.adjustProgressBar.originalProgress + (deltaX / taskBarWidth) * 100)
+    );
+
+    if (Math.abs(newProgress - this.adjustProgressBar.originalProgress) >= 1) {
+      const taskIndex = target.task_index;
+      const subTaskIndex = target.sub_task_index;
+
+      // 更新数据
+      this._gantt._updateProgressToTaskRecord(Math.round(newProgress), taskIndex, subTaskIndex);
+      const newRecord = this._gantt.getRecordByIndex(taskIndex, subTaskIndex);
+
+      // 刷新任务条显示
+      this._gantt.scenegraph.taskBar.updateTaskBarNode(taskIndex, subTaskIndex);
+
+      // 触发进度更新事件
+      if (this._gantt.hasListeners(GANTT_EVENT_TYPE.PROGRESS_UPDATE)) {
+        this._gantt.fireListeners(GANTT_EVENT_TYPE.PROGRESS_UPDATE, {
+          federatedEvent: null,
+          event: null,
+          index: taskIndex,
+          sub_task_index: subTaskIndex,
+          progress: Math.round(newProgress),
+          oldProgress: Math.round(this.adjustProgressBar.originalProgress),
+          record: newRecord
+        });
+      }
+    }
+
+    // 重置状态
+    this.adjustProgressBar.adjusting = false;
+    this.adjustProgressBar.target = null;
+    this.adjustProgressBar.startX = null;
+    this.adjustProgressBar.startY = null;
+    this.adjustProgressBar.originalProgress = 0;
+  }
+  dealAdjustProgressBar(e: FederatedPointerEvent) {
+    const target = this.adjustProgressBar.target;
+    const taskBarWidth = target.attribute.width;
+    const deltaX = e.x - this.adjustProgressBar.startX;
+    const newProgress = Math.max(
+      0,
+      Math.min(100, this.adjustProgressBar.originalProgress + (deltaX / taskBarWidth) * 100)
+    );
+
+    // 更新进度条显示
+    if (target.progressRect) {
+      target.progressRect.setAttribute('width', (taskBarWidth * newProgress) / 100);
+    }
+
+    // 更新进度手柄位置
+    if (
+      this._gantt.scenegraph.taskBar.hoverBarProgressHandle &&
+      this._gantt.scenegraph.taskBar.hoverBarProgressHandle.attribute.visibleAll
+    ) {
+      this._gantt.scenegraph.taskBar.hoverBarProgressHandle.setAttribute('x', (taskBarWidth * newProgress) / 100 - 6);
+    }
+
+    // 更新文字标签中的进度百分比
+    if (target.textLabel && target.record) {
+      const tempRecord = { ...target.record, progress: Math.round(newProgress) };
+      const newText = parseStringTemplate(this._gantt.parsedOptions.taskBarLabelText as string, tempRecord);
+      target.textLabel.setAttribute('text', newText);
+    }
+
+    // 实时显示变化
+    if (this._gantt.scenegraph && this._gantt.scenegraph.stage) {
+      this._gantt.scenegraph.stage.renderNextFrame();
+    }
   }
   //#endregion
   //#region 生成关联线的交互处理

--- a/packages/vtable-gantt/src/ts-types/EVENT_TYPE.ts
+++ b/packages/vtable-gantt/src/ts-types/EVENT_TYPE.ts
@@ -50,6 +50,8 @@ export interface EVENT_TYPES {
 
   /** 移动任务条结束事件 */
   MOVE_END_TASK_BAR: 'move_end_task_bar';
+  /** 进度调整事件 */
+  PROGRESS_UPDATE: 'progress_update';
 }
 /**
  * GanttChart event types
@@ -68,5 +70,6 @@ export const GANTT_EVENT_TYPE: EVENT_TYPES = {
   CONTEXTMENU_DEPENDENCY_LINK: 'contextmenu_dependency_link',
   CLICK_MARKLINE_CREATE: 'click_markline_create',
   CLICK_MARKLINE_CONTENT: 'click_markline_content',
-  MOVE_END_TASK_BAR: 'move_end_task_bar'
+  MOVE_END_TASK_BAR: 'move_end_task_bar',
+  PROGRESS_UPDATE: 'progress_update'
 } as EVENT_TYPES;

--- a/packages/vtable-gantt/src/ts-types/events.ts
+++ b/packages/vtable-gantt/src/ts-types/events.ts
@@ -132,6 +132,19 @@ export interface TableEventHandlersEventArgumentMap {
     data: IMarkLine;
     position: IPosition;
   };
+  progress_update: {
+    federatedEvent: FederatedPointerEvent;
+    event: Event;
+    /** 第几条数据 */
+    index: number;
+    sub_task_index?: number;
+    /** 新的进度值 */
+    progress: number;
+    /** 原来的进度值 */
+    oldProgress: number;
+    /** 改变后的数据条目 */
+    record: any;
+  };
 }
 
 export interface TableEventHandlersReturnMap {
@@ -148,4 +161,6 @@ export interface TableEventHandlersReturnMap {
   click_markline_create: void;
   click_markline_content: void;
   move_end_task_bar: void;
+  progress_update: void;
+  click_dependency_link_point: void;
 }

--- a/packages/vtable-gantt/src/ts-types/gantt-engine.ts
+++ b/packages/vtable-gantt/src/ts-types/gantt-engine.ts
@@ -104,6 +104,8 @@ export interface GanttConstructorOptions {
       | ((interactionArgs: TaskBarInteractionArgumentType) => boolean | [boolean, boolean]);
     /** 任务条是否可移动 */
     moveable?: boolean | ((interactionArgs: TaskBarInteractionArgumentType) => boolean);
+    /** 任务进度是否可调整 */
+    progressAdjustable?: boolean | ((interactionArgs: TaskBarInteractionArgumentType) => boolean);
     /** 任务条拖拽超出当前日期范围时自动扩展日期范围 */
     moveToExtendDateRange?: boolean;
     /** 任务条是否可以被拖拽来改变顺序 */


### PR DESCRIPTION
### 🤔 这个分支是...

- [x] 新功能
- [ ] Bug fix
- [ ] Ts 类型更新
- [ ] 打包优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 重构
- [ ] 依赖版本更新
- [x] 代码优化
- [ ] 测试 case 更新
- [ ] 分支合并
- [x] 网站/文档更新
- [ ] demo 更新
- [ ] Workflow
- [ ] 配置修改
- [ ] 发布
- [ ] 其他 (具体是什么，请补充?)

### 🔗 相关 issue 连接

close #3270 

### 💡 问题的背景&解决方案

<!--
1. 描述问题和场景
2. 如果包含UI/交互相关的修改，请提供GIF或者截图
3. 提供如何解决问题的，如果是开发新的功能，请提供最终的API实现和使用案例
-->
在甘特图的使用场景中，用户经常需要动态调整任务的进度百分比。之前的版本中，进度只能通过数据更新来修改，缺乏直观的交互方式。用户反馈希望能够像调整任务条大小一样，通过拖拽的方式来调整任务进度。

#### 解决方案
新增了进度调整功能，允许用户通过拖拽进度手柄来交互式地调整任务进度：
进度手柄: 在任务条hover时显示进度调整手柄，位于进度条下方
拖拽交互: 用户可以拖拽手柄左右移动来调整进度百分比（0-100%）
实时反馈: 拖拽过程中实时更新进度条显示和文本标签
配置控制: 新增progressAdjustable配置项，支持全局开关和基于任务的动态控制

### 📝 Changelog

<!--
描述用户侧的修改，并列出所有可能的新功能、修改、以及风险
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |feat: Add interactive progress adjustment feature<br/>1. Add taskBar.progressAdjustable configuration option to control progress adjustment capability<br/>2. Support both boolean and function types for fine-grained control<br/>3. Add progress handle that appears on task bar hover<br/>4. Enable drag interaction to adjust progress percentage (0-100%)           |
| 🇨🇳 Chinese | feat: 新增交互式进度调整功能<br/>1. 新增 taskBar.progressAdjustable 配置项控制进度调整能力<br/>2. 支持布尔值和函数类型，提供精细化控制<br/>3. 任务条hover时显示进度调整手柄<br/>4. 支持拖拽交互调整进度百分比（0-100%）       |

### ☑️ 自测

⚠️ 在提交 PR 之前，请检查一下内容. ⚠️

- [x] 文档提供了，或者更新，或者不需要
- [x] Demo 提供了，或者更新，或者不需要
- [x] Ts 类型定义提供了，或者更新，或者不需要
- [x] Changelog 提供了，或者不需要

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough

