### PR TITLE
fix: the serial number column configuration field

### DIFF
--- a/packages/vtable/src/ListTable.ts
+++ b/packages/vtable/src/ListTable.ts
@@ -399,7 +399,7 @@ export class ListTable extends BaseTable implements ListTableAPI {
       } else {
         const define = table.getBodyColumnDefine(col, row);
         const checkboxSeriesNumberStyle = (table as ListTable).getFieldData(define.field, col, row);
-        if (typeof checkboxSeriesNumberStyle === 'string') {
+        if (['number', 'string'].includes(typeof checkboxSeriesNumberStyle)) {
           value = checkboxSeriesNumberStyle;
         } else if (checkboxSeriesNumberStyle?.text) {
           value = checkboxSeriesNumberStyle.text ?? '';


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/VTable/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link

[fix: 4478 问题5](https://github.com/VisActor/VTable/issues/4478)

### 💡 Background and solution
当序号列配置的字段的对应值是数字时不生效
```ts
  const option = {
    rowSeriesNumber: {
      field: 'id' // 对应行的值是数字
    }
  };
```

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the issue where the serial number column configuration field (corresponding to a number) did not take effect |
| 🇨🇳 Chinese |  修复序号列配置字段(对应值是数字时)不生效问题   |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
