### PR TITLE
fix: the use of changeOrder in pagination mode

### DIFF
--- a/packages/vtable/src/data/DataSource.ts
+++ b/packages/vtable/src/data/DataSource.ts
@@ -1531,26 +1531,30 @@ export class DataSource extends EventTarget implements DataSourceAPI {
             Array.prototype.splice.apply(this.records, sourceIds);
           }
         } else {
-          sourceI = this.currentPagerIndexedData[sourceIndex] as number;
-          targetI = this.currentPagerIndexedData[targetIndex];
-          // 从source的二维数组中取出需要操作的records
-          const records = this.records.splice(sourceI, 1);
-          // 将records插入到目标地址targetIndex处
-          // 把records变成一个适合splice的数组（包含splice前2个参数的数组） 以通过splice来插入到source数组
-          records.unshift(targetI, 0);
-          Array.prototype.splice.apply(this.records, records);
+          this.exchangeRecordData(sourceIndex, targetIndex);
         }
         this.restoreTreeHierarchyState();
         this.updatePagerData();
       } else {
-        // 从source的二维数组中取出需要操作的records
-        const records = this.records.splice(sourceIndex, 1);
-        // 将records插入到目标地址targetIndex处
-        // 把records变成一个适合splice的数组（包含splice前2个参数的数组） 以通过splice来插入到source数组
-        records.unshift(targetIndex, 0);
-        Array.prototype.splice.apply(this.records, records);
+        this.exchangeRecordData(sourceIndex, targetIndex);
       }
     }
+  }
+
+  /**
+   * @description: 交换源数据
+   * @param {number} sourceIndex 源索引
+   * @param {number} targetIndex 目标索引
+   */
+  exchangeRecordData(sourceIndex: number, targetIndex: number) {
+    const sourceI = this.getRecordIndexPaths(sourceIndex) as number;
+    const targetI = this.getRecordIndexPaths(targetIndex) as number;
+    // 从source的二维数组中取出需要操作的records
+    const records = this.records.splice(sourceI, 1);
+    // 将records插入到目标地址targetIndex处
+    // 把records变成一个适合splice的数组（包含splice前2个参数的数组） 以通过splice来插入到source数组
+    records.unshift(targetI, 0);
+    Array.prototype.splice.apply(this.records, records);
   }
 
   restoreTreeHierarchyState() {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/VTable/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link

[fix: 4478 问题3](https://github.com/VisActor/VTable/issues/4478)

### 💡 Background and solution

在分页模式下的 ListTable 1页之后的数据行拖动不正确

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the row dragging issue of listTable in pagination mode |
| 🇨🇳 Chinese | 修复分页模式下的 listTable 的行拖动问题 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
