### PR TITLE
fix: dragOrder type error

### DIFF
--- a/packages/vtable-sheet/src/ts-types/index.ts
+++ b/packages/vtable-sheet/src/ts-types/index.ts
@@ -112,9 +112,9 @@ export interface IVTableSheetOptions {
   /** 默认列宽 */
   defaultColWidth?: number;
   /** 拖拽列顺序和行顺序配置 如果sheets中单独配置过，这个配置会被忽略*/
-  dragOrder: {
-    enableDragColumnOrder: true;
-    enableDragRowOrder: true;
+  dragOrder?: {
+    enableDragColumnOrder?: boolean;
+    enableDragRowOrder?: boolean;
   };
 }
 export * from './base';


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link

None

### 💡 Background and solution

The `dragOrder` type definition is weird and misaligned with the `ISheetDefine` interface, which seems erroneous.

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the options interface for initializing a VTableSheet |
| 🇨🇳 Chinese | 修改初始化VTableSheet的参数类型 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
