### PR TITLE
fix: auto-update value-filter options when table data changes

### DIFF
--- a/packages/vtable-plugins/src/filter/filter.ts
+++ b/packages/vtable-plugins/src/filter/filter.ts
@@ -139,15 +139,18 @@ export class FilterPlugin implements pluginsDefinition.IVTablePlugin {
   }
 
   syncFilterWithTableData(field?: string | number) {
-    if (field !== null && field !== undefined) {
-      this.filterToolbar.valueFilter.syncSingleStateFromTableData(field);
-      return;
-    }
+    const filterType = this.filterStateManager.getFilterState(field)?.type;
+    if (filterType === 'byValue') {
+      if (field !== null && field !== undefined) {
+        this.filterToolbar.valueFilter.syncSingleStateFromTableData(field);
+        return;
+      }
 
-    const columns = this.table.dataSource.columns;
-    columns.forEach(({ field }) => {
-      this.filterToolbar.valueFilter.syncSingleStateFromTableData(field as string | number);
-    });
+      const columns = this.table.dataSource.columns;
+      columns.forEach(({ field }) => {
+        this.filterToolbar.valueFilter.syncSingleStateFromTableData(field as string | number);
+      });
+    }
   }
 
   /**

--- a/packages/vtable-plugins/src/filter/value-filter.ts
+++ b/packages/vtable-plugins/src/filter/value-filter.ts
@@ -93,6 +93,10 @@ export class ValueFilter {
     const recordsList = this.table.internalProps.records; // 已筛选：使用原始表格数据
     const records = recordsList.filter(record =>
       filteredFields.every(field => {
+        const filterType = this.filterStateManager.getFilterState(field)?.type;
+        if (filterType !== 'byValue' && filterType !== null && filterType !== undefined) {
+          this.syncSingleStateFromTableData(field);
+        }
         const set = this.selectedKeys.get(field);
         return set.has(record[field]);
       })
@@ -382,12 +386,18 @@ export class ValueFilter {
       this.collectCandidateKeysForFilteredColumn(this.selectedField);
     }
 
-    // 2. 清空搜索框
+    // 2. 初始筛选状态
+    const filterType = this.filterStateManager.getFilterState(this.selectedField)?.type;
+    if (filterType !== null && filterType !== undefined && filterType !== 'byValue') {
+      this.syncSingleStateFromTableData(this.selectedField);
+    }
+
+    // 3. 清空搜索框
     if (this.filterByValueSearchInput) {
       this.filterByValueSearchInput.value = '';
     }
 
-    // 3. 渲染选项（此时状态已经初始化完成）
+    // 4. 渲染选项（此时状态已经初始化完成）
     this.renderFilterOptions(this.selectedField);
     this.filterByValuePanel.style.display = 'block';
   }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/VTable/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link
#4757
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
当单元格数据发生变化，以及从 按条件筛选 转换为 按值筛选 时，重新从当前真实的表格数据中搜集筛选选项
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | auto update value-filter options when table data changes. Prevent crash when filtering by value after conditional filter |
| 🇨🇳 Chinese | 当表格数据更改时，更新筛选的选项；修复按条件筛选后再按值筛选会崩溃的问题 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
