### PR TITLE
fix: resolve empty data issue with both grouping and filtering

### DIFF
--- a/packages/vtable-plugins/src/filter/value-filter.ts
+++ b/packages/vtable-plugins/src/filter/value-filter.ts
@@ -53,12 +53,34 @@ export class ValueFilter {
     return formatFn;
   }
 
+  private getRecords(table: ListTable | PivotTable, original: boolean): any[] {
+    if (original === true) {
+      return table.internalProps.records;
+    }
+
+    const records = [];
+    const stack = [...table.internalProps.dataSource.records];
+    while (stack.length > 0) {
+      const item = stack.pop();
+
+      if (item.vtableMerge && Array.isArray(item.children)) {
+        for (let i = item.children.length - 1; i >= 0; i--) {
+          stack.push(item.children[i]);
+        }
+      } else {
+        records.push(item);
+      }
+    }
+
+    return records.reverse();
+  }
+
   /**
    * 为未应用筛选的列，收集候选值集合
    */
   private collectCandidateKeysForUnfilteredColumn(fieldId: string | number): void {
     const countMap = new Map<any, number>(); // 计算每个候选值的计数
-    const records = this.table.internalProps.dataSource.records; // 未筛选：使用当前表格数据
+    const records = this.getRecords(this.table, false); // 未筛选：使用当前表格数据
     const formatFn = this.getFormatFnCache(fieldId);
     const toUnformatted = new Map();
 
@@ -90,7 +112,7 @@ export class ValueFilter {
     const formatFn = this.getFormatFnCache(candidateField);
 
     const countMap = new Map<any, number>(); // 计算每个候选值的计数
-    const recordsList = this.table.internalProps.records; // 已筛选：使用原始表格数据
+    const recordsList = this.getRecords(this.table, true); // 已筛选：使用原始表格数据
     const records = recordsList.filter(record =>
       filteredFields.every(field => {
         const set = this.selectedKeys.get(field);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/VTable/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link
#4779 
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
问题：同时使用分组和筛选时,筛选面板出现无数据的异常
解决方法：对于数据来源（table.internalProps.records/table.internalProps.dataSource.records) 进行初步处理，考虑数据分组的情况
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | resolve empty data issue with both grouping and filtering  |
| 🇨🇳 Chinese | 解决了 同时使用分组和筛选时,筛选出现无数据异常 的问题 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
