### PR TITLE
fix(gantt): correct month difference calculation for variable month lengths

### DIFF
--- a/packages/vtable-gantt/src/tools/util.ts
+++ b/packages/vtable-gantt/src/tools/util.ts
@@ -677,6 +677,10 @@ export function computeCountToTimeScale(
 
   let difference: number;
   const adjusted_date = new Date(date.getTime() + diffMS);
+
+  const startDaysInMonth = new Date(startDate.getFullYear(), startDate.getMonth() + 1, 0).getDate();
+  const adjustedDaysInMonth = new Date(adjusted_date.getFullYear(), adjusted_date.getMonth() + 1, 0).getDate();
+
   switch (timeScale) {
     case 'second':
       difference = (adjusted_date.getTime() - startDate.getTime()) / msInSecond;
@@ -697,9 +701,10 @@ export function computeCountToTimeScale(
       difference =
         (adjusted_date.getFullYear() - startDate.getFullYear()) * 12 +
         (adjusted_date.getMonth() - startDate.getMonth());
-      difference +=
-        (adjusted_date.getDate() - startDate.getDate()) /
-        new Date(adjusted_date.getFullYear(), adjusted_date.getMonth() + 1, 0).getDate();
+
+      // Calculate fractional difference by normalizing day progress within each specific month
+      // This handles variable month lengths (28/29/30/31 days) correctly
+      difference += adjusted_date.getDate() / adjustedDaysInMonth - startDate.getDate() / startDaysInMonth;
       break;
     case 'quarter':
       difference =


### PR DESCRIPTION
<!--
首先，感谢您参与代码贡献! 😄
为了提交新的功能或修改,请在主分支`main`分支上拉取开发分支 。
在提交PR 之前，请确认下面列到的一些内容
你的PR在核心成员review后，合并到主分支
谢谢！
-->

### 🤔 这个分支是...

- [x] Bug fix

### 🔗 相关 issue 连接

<!--
1. 相关的issue或者讨论，请贴在这里.
2. close #xxxx or fix #xxxx for instance.
-->

原有的计算逻辑存在缺陷，特别是在跨越不同天数的月份时（如从 31 天的 1 月到 28 天的 2 月）。

*   **原逻辑问题**：在计算不足一个月的零头天数差时，统一使用了 `adjusted_date`（结束日期）所在月份的总天数作为分母。
    *   公式：`MonthDiff + (adjusted_date - StartDay) / EndMonthDays`
    *   重现： `computeCountToTimeScale('2026-01-31', '2026-02-05', 'month', 1, 1)`
    *   **案例（2026年1月31日 - 2月5日）**：
        *   结果：宽度为0


### 💡 问题的背景&解决方案

<!--
1. 描述问题和场景
2. 如果包含UI/交互相关的修改，请提供GIF或者截图
3. 提供如何解决问题的，如果是开发新的功能，请提供最终的API实现和使用案例
-->

### 1. 修复方案

我已将计算逻辑修改为分别计算开始日期和结束日期在各自月份中的进度比例，然后求差。

*   **新逻辑**：`MonthDiff + (EndDay / EndMonthDays) - (StartDay / StartMonthDays)`
*   **验证（2026年1月31日 - 2月5日）**：
    *   月份差：1
    *   结束进度（2月5日）：`5 / 28 ≈ 0.1786`
    *   开始进度（1月31日）：`31 / 31 = 1.0`
    *   结果：`1 + 0.1786 - 1.0 = 0.1786` 个月（符合预期）


### 📝 Changelog

<!--
描述用户侧的修改，并列出所有可能的新功能、修改、以及风险
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ 自测

⚠️ 在提交 PR 之前，请检查一下内容. ⚠️

- [x] 不需要
- [x] 不需要
- [x] 不需要
- [x] 不需要

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough