### PR TITLE
feat(vtable): support componentLayoutOrder to control title/legend la…

### DIFF
--- a/packages/vtable/README.md
+++ b/packages/vtable/README.md
@@ -118,10 +118,30 @@ const option = {
   widthMode:'standard'
 };
 const tableInstance = new VTable.ListTable(document.getElementById(CONTAINER_ID), option);
+```
 
+## Component Layout Priority
 
+The `componentLayoutOrder` option allows you to control the layout priority of `title` and `legend`. This affects the order in which they occupy space in the drawing area. By default, the order is `['legend', 'title']`.
 
+To place the title above the legend, you can configure it as follows:
 
+```javascript
+const option = {
+  // ...other options
+  title: {
+    text: 'Sales Analysis',
+    orient: 'top',
+    align: 'center'
+  },
+  legends: {
+    orient: 'top',
+    // ...other legend options
+  },
+  componentLayoutOrder: ['title', 'legend']
+};
+
+const tableInstance = new VTable.ListTable(document.getElementById(CONTAINER_ID), option);
 ```
 
 ##

--- a/packages/vtable/examples/components/legend-title-order.ts
+++ b/packages/vtable/examples/components/legend-title-order.ts
@@ -1,0 +1,69 @@
+import * as VTable from '../../src';
+
+const CONTAINER_ID = 'vTable';
+
+export function createTable() {
+  const records = [
+    { category: 'A', value: 120 },
+    { category: 'B', value: 90 },
+    { category: 'C', value: 60 }
+  ];
+
+  const columns: VTable.ColumnsDefine = [
+    {
+      field: 'category',
+      title: 'Category',
+      width: 120
+    },
+    {
+      field: 'value',
+      title: 'Value',
+      width: 120
+    }
+  ];
+
+  const option: VTable.ListTableConstructorOptions = {
+    container: document.getElementById(CONTAINER_ID),
+    records,
+    columns,
+    // place title and legend both at the top
+    title: {
+      text: 'Title above legend (componentLayoutOrder)',
+      orient: 'top',
+      align: 'center'
+    },
+    legends: {
+      type: 'discrete',
+      orient: 'top',
+      position: 'middle',
+      data: [
+        {
+          label: 'A',
+          shape: {
+            fill: '#1664FF',
+            symbolType: 'circle'
+          }
+        },
+        {
+          label: 'B',
+          shape: {
+            fill: '#1AC6FF',
+            symbolType: 'square'
+          }
+        },
+        {
+          label: 'C',
+          shape: {
+            fill: '#FFCC00',
+            symbolType: 'triangle'
+          }
+        }
+      ]
+    },
+    // ensure title is laid out before legend so legend appears under the title
+    componentLayoutOrder: ['title', 'legend']
+  };
+
+  const tableInstance = new VTable.ListTable(option);
+  (window as any).tableInstance = tableInstance;
+}

--- a/packages/vtable/src/ListTable.ts
+++ b/packages/vtable/src/ListTable.ts
@@ -184,6 +184,7 @@ export class ListTable extends BaseTable implements ListTableAPI {
       if (this.isReleased) {
         return;
       }
+      // 首次布局同样通过 BaseTable.resize() 完成，遵循 componentLayoutOrder 中的 title/legend 优先级
       this.resize();
       this.fireListeners(TABLE_EVENT_TYPE.INITIALIZED, null);
     }, 0);

--- a/packages/vtable/src/PivotChart.ts
+++ b/packages/vtable/src/PivotChart.ts
@@ -288,6 +288,7 @@ export class PivotChart extends BaseTable implements PivotChartAPI {
       if (this.isReleased) {
         return;
       }
+      // 首次布局同样通过 BaseTable.resize() 完成，遵循 componentLayoutOrder 中的 title/legend 优先级
       this.resize();
       this.fireListeners(TABLE_EVENT_TYPE.INITIALIZED, null);
     }, 0);

--- a/packages/vtable/src/PivotTable.ts
+++ b/packages/vtable/src/PivotTable.ts
@@ -259,6 +259,7 @@ export class PivotTable extends BaseTable implements PivotTableAPI {
         if (this.isReleased) {
           return;
         }
+        // 首次布局同样通过 BaseTable.resize() 完成，遵循 componentLayoutOrder 中的 title/legend 优先级
         this.resize();
         this.fireListeners(TABLE_EVENT_TYPE.INITIALIZED, null);
       }, 0);

--- a/packages/vtable/src/core/BaseTable.ts
+++ b/packages/vtable/src/core/BaseTable.ts
@@ -680,12 +680,17 @@ export abstract class BaseTable extends EventTarget implements BaseTableAPI {
   }
   resize() {
     this._updateSize();
-    this.internalProps.legends?.forEach(legend => {
-      legend?.resize();
+    // 组件布局优先级仅影响 title/legend 的布局与可用绘制区域缩减顺序
+    const layoutOrder = this.options.componentLayoutOrder ?? ['legend', 'title'];
+    layoutOrder.forEach(component => {
+      if (component === 'legend') {
+        this.internalProps.legends?.forEach(legend => {
+          legend?.resize();
+        });
+      } else if (component === 'title') {
+        this.internalProps.title?.resize();
+      }
     });
-    if (this.internalProps.title) {
-      this.internalProps.title.resize();
-    }
     if (this.internalProps.emptyTip) {
       this.internalProps.emptyTip.resize();
     }

--- a/packages/vtable/src/ts-types/base-table.ts
+++ b/packages/vtable/src/ts-types/base-table.ts
@@ -514,6 +514,12 @@ export interface BaseTableConstructorOptions {
 
   legends?: ITableLegendOption | ITableLegendOption[];
   title?: ITitle;
+  /**
+   * 标题与图例的布局计算顺序，仅影响两者的布局与可用绘制区域的缩减顺序。
+   *
+   * 默认不配置时等价于 ['legend', 'title']，与现有行为保持一致。
+   */
+  componentLayoutOrder?: ('legend' | 'title')[];
   emptyTip?: true | IEmptyTip;
   /** 是否开启图表异步渲染 */
   renderChartAsync?: boolean;


### PR DESCRIPTION
…yout priority

### Summary

- Introduce `componentLayoutOrder` option on `BaseTableConstructorOptions` to control layout priority between `title` and `legend` while preserving existing default behavior.
- Update `BaseTable.resize()` to apply layout (and available drawing area shrinking) in the order defined by `componentLayoutOrder`, so that `title` and legends sharing the same orient (such as `top`) can be stacked deterministically.

### Details

- **Types**
  - Extended `BaseTableConstructorOptions` in `packages/vtable/src/ts-types/base-table.ts` with:
    - `componentLayoutOrder?: ('legend' | 'title')[]` including JSDoc explaining default behavior and compatibility.
- **Runtime behavior**
  - Updated `BaseTable.resize()` in `packages/vtable/src/core/BaseTable.ts`:
    - After `_updateSize()`, iterate over `this.options.componentLayoutOrder ?? ['legend', 'title']`.
    - For `legend`, call `resize()` on each legend in `this.internalProps.legends`.
    - For `title`, call `resize()` on `this.internalProps.title` when present.
    - Keep `emptyTip` resize and `scenegraph.resize()` behavior unchanged.
  - Added comments in `ListTable`, `PivotChart`, and `PivotTable` constructors to clarify that the first layout after initialization also goes through `BaseTable.resize()` and therefore respects `componentLayoutOrder`.
- **Examples & docs**
  - Added a new example `packages/vtable/examples/components/legend-title-order.ts` using `ListTable` that demonstrates `componentLayoutOrder: ['title', 'legend']` with both title and legends at `orient: 'top'` so legend is laid out below the title.
  - Updated `packages/vtable/README.md` to add a "Component Layout Priority" section after the Usage chapter, documenting `componentLayoutOrder`, its default value, and a small code snippet in English showing how to place the title above legends.

### Testing & Quality

- **standard-lint**
  - Command (Node 18.20.0):
    - `standard-lint` run against the modified TS files in `packages/vtable`.
  - Result:
    - Failed due to multiple pre-existing lint issues (e.g. `byted_s_ts_no_unused_vars` and `byted_s_js_guard_for_in`) in `BaseTable.ts` and `ts-types/base-table.ts`, unrelated to this change and impacting large legacy sections.
  - I did not modify unrelated legacy logic to avoid introducing risky changes.
- **tsc-files**
  - Command (Node 18.20.0):
    - `npx @byted/tsc-files-mono` on the same TS files.
  - Result:
    - Failed with `TS6053: File '@internal/ts-config/tsconfig.base.json' not found.`
    - Root cause: the repo's TypeScript configuration depends on internal package `@internal/ts-config` which is not available in the current environment (monorepo dependencies are not fully installed), so `tsc-files` cannot resolve the shared base tsconfig.

Given these constraints, the new feature is implemented and wired into examples and docs, while lint/tsc failures are due to existing repository configuration and historical issues rather than the new code.


Change-Id: If2b110b4443dc1fba58acfa9bc2f0e97759a4b7c

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/VTable/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
