### PR TITLE
fix(vtable): 修复透视表维度隐藏后点击排序失效的问题

### DIFF
--- a/packages/vtable/src/PivotTable.ts
+++ b/packages/vtable/src/PivotTable.ts
@@ -1126,13 +1126,7 @@ export class PivotTable extends BaseTable implements PivotTableAPI {
     this.dataset.updateSortRules(sortRules);
     this._changePivotSortStateBySortRules();
     // 排序后dataset重新生成了树结构，需要重新过滤hide指标节点
-    const options = this.options;
-    if (options.indicatorsAsCol !== false && options.indicators && this.dataset.colHeaderTree) {
-      deleteHideIndicatorNode(this.dataset.colHeaderTree, options.indicators, false, this);
-    }
-    if (options.indicatorsAsCol === false && this.dataset.rowHeaderTree && options.indicators) {
-      deleteHideIndicatorNode(this.dataset.rowHeaderTree, options.indicators, false, this);
-    }
+    this._filterHideIndicatorNode();
     const { layoutMap } = this.internalProps;
     layoutMap.resetHeaderTree();
     // 清空单元格内容
@@ -1199,6 +1193,17 @@ export class PivotTable extends BaseTable implements PivotTableAPI {
         order: SortType[sortType]
       });
       // }
+    }
+  }
+
+  // 重新过滤hide指标节点
+  _filterHideIndicatorNode() {
+    const options = this.options;
+    if (options.indicatorsAsCol !== false && options.indicators && this.dataset.colHeaderTree) {
+      deleteHideIndicatorNode(this.dataset.colHeaderTree, options.indicators, false, this);
+    }
+    if (options.indicatorsAsCol === false && this.dataset.rowHeaderTree && options.indicators) {
+      deleteHideIndicatorNode(this.dataset.rowHeaderTree, options.indicators, false, this);
     }
   }
 
@@ -2219,13 +2224,7 @@ export class PivotTable extends BaseTable implements PivotTableAPI {
       // 由于筛选数据可能导致行列变化，所以需要重置树结构
       this.dataset.updateFilterRules(filterRules, true);
       // 筛选后dataset重新生成了树结构，需要重新过滤hide指标节点
-      const options = this.options;
-      if (options.indicatorsAsCol !== false && options.indicators && this.dataset.colHeaderTree) {
-        deleteHideIndicatorNode(this.dataset.colHeaderTree, options.indicators, false, this);
-      }
-      if (options.indicatorsAsCol === false && this.dataset.rowHeaderTree && options.indicators) {
-        deleteHideIndicatorNode(this.dataset.rowHeaderTree, options.indicators, false, this);
-      }
+      this._filterHideIndicatorNode();
       this.internalProps.layoutMap.resetHeaderTree();
     } else {
       this.dataset.updateFilterRules(filterRules);


### PR DESCRIPTION
### 🤔 This is a ...

- [x] Bug fix

### 🔗 Related issue link

fix #5029

### 💡 Background and solution

**Problem:** In the PivotTable component, when a dimension is configured with `hide: true`, the column/row correctly disappears initially. However, after triggering a sort action on other dimensions, the internal state of the table headers is recalculated without properly respecting the `hide` attribute, causing the hidden dimensions to reappear.

**Solution:**
Modified `packages/vtable/src/PivotTable.ts`. Ensured that the `hide` property from the dimension configuration is correctly preserved and applied during the header re-generation process that follows a sort or update event.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the issue where hidden dimensions (`hide:true`) in PivotTable would reappear after sorting other dimensions. |
| 🇨🇳 Chinese | 修复透视表维度配置 `hide:true` 隐藏后，点击其他维度排序导致隐藏维度重新显示的问题。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed