### PR TITLE
fix(filter): show correct tab when filterModes only contains byCondition

### DIFF
--- a/packages/vtable-plugins/src/filter/filter-toolbar.ts
+++ b/packages/vtable-plugins/src/filter/filter-toolbar.ts
@@ -292,7 +292,7 @@ export class FilterToolbar {
     const currentFilter = this.filterStateManager.getFilterState(field);
     if (currentFilter && currentFilter.type === 'byCondition') {
       this.onTabSwitch('byCondition');
-    } else {
+    } else if (this.filterModes.includes('byValue')) {
       this.onTabSwitch('byValue');
     }
 


### PR DESCRIPTION
## 变更说明

当 `filterModes` 仅配置为 `['byCondition']` 时，首次打开筛选面板会错误地显示「按值筛选」页，点击一次后才切换正常。

**根因**：`FilterToolbar.show()` 中存在两段独立的 tab 切换逻辑：

1. 第一段根据 `filterModes` 正确切换到 `byCondition` ✅
2. 第二段根据已有 filter 状态切换，但 `else` 分支无条件调用 `onTabSwitch('byValue')`，覆盖了第一段的设置 ❌

**修复**：在第二段的 `else` 分支加入 `filterModes.includes('byValue')` 条件判断，避免在 `byValue` 不可用时错误覆盖。

```diff
- } else {
+ } else if (this.filterModes.includes('byValue')) {
    this.onTabSwitch('byValue');
  }
```

## 关联 Issue

Closes #4968

## 测试

- [ ] 配置 `filterModes: ['byCondition']`，首次打开筛选面板直接显示「按条件筛选」页
- [ ] 配置 `filterModes: ['byValue']`，首次打开筛选面板显示「按值筛选」页（原有行为不受影响）
- [ ] 两种模式都配置时，已有 `byCondition` 筛选的列打开面板显示条件页；其余列显示值页