### PR TITLE
fix(table): use rowHeightsMap directly in scrollToCell to fix position with dynamic row heights

### DIFF
--- a/packages/vtable/src/core/BaseTable.ts
+++ b/packages/vtable/src/core/BaseTable.ts
@@ -5022,8 +5022,12 @@ export abstract class BaseTable extends EventTarget implements BaseTableAPI {
     }
     if (isValid(cellAddr.row) && cellAddr.row >= this.frozenRowCount) {
       const frozenHeight = this.getFrozenRowsHeight();
-      const top = this.getRowsHeight(0, cellAddr.row - 1);
-      this.scrollTop = Math.min(top - frozenHeight, this.getAllRowsHeight() - drawRange.height);
+      // Use rowHeightsMap.getSumInRange directly to bypass the getRowsHeight fast path,
+      // which ignores rowHeightsMap for body rows and uses defaultRowHeight*count instead.
+      // This ensures dynamically-computed row heights (e.g. autoWrapText) are reflected
+      // in the scroll position calculation.
+      const top = this.rowHeightsMap.getSumInRange(0, cellAddr.row - 1);
+      this.scrollTop = Math.min(top - frozenHeight, this.rowHeightsMap.getSumInRange(0, this.rowCount - 1) - drawRange.height);
     }
     this.render();
   }


### PR DESCRIPTION
## 变更说明

`scrollToRow` / `scrollToCell` 在使用动态行高（如 `autoWrapText: true`）时，滚动位置不准确，特别是在最后一两屏时偏差明显。

**根因分析**：

`scrollToCell` 调用 `getRowsHeight(0, row-1)` 计算目标行的像素位置。该函数存在一个 fast path：当 `heightMode === 'standard'` 且 `_heightResizedRowMap.size === 0` 时，对 body rows 直接用 `defaultRowHeight × count` 计算，**完全忽略** `rowHeightsMap` 中存储的实际行高。

`autoWrapText` 渲染时通过 `_setRowHeight` 将实际行高写入 `rowHeightsMap`，但不会写入 `_heightResizedRowMap`，因此 fast path 的条件始终成立，导致已计算的实际行高被忽略。

结果：目标滚动位置（`top`）和最大滚动上限（`getAllRowsHeight() - drawHeight`）均基于 `defaultRowHeight` 估算，与实际像素偏移不符。

**修复**：在 `scrollToCell` 中直接使用 `rowHeightsMap.getSumInRange` 计算行高偏移，绕过 fast path。对于未渲染的行，`getSumInRange` 内部同样回落到 `getRowHeight(i)`（`defaultRowHeight`），故未渲染行的行为不变。

```diff
-const top = this.getRowsHeight(0, cellAddr.row - 1);
-this.scrollTop = Math.min(top - frozenHeight, this.getAllRowsHeight() - drawRange.height);
+const top = this.rowHeightsMap.getSumInRange(0, cellAddr.row - 1);
+this.scrollTop = Math.min(top - frozenHeight, this.rowHeightsMap.getSumInRange(0, this.rowCount - 1) - drawRange.height);
```

## 关联 Issue

Closes #5020

## 测试

- [ ] `autoWrapText: true` + 10000 条数据，调用 `scrollToRow(9990)`，确认滚动位置正确（目标行出现在视口内）
- [ ] 无 `autoWrapText` 的普通表格 `scrollToRow` 行为不变
- [ ] 用户手动拖拽调整行高后 `scrollToRow` 位置正确