### PR TITLE
fix: radio cell should fallback to text in aggregation row #4027

### DIFF
--- a/common/changes/@visactor/vtable/fix-radio-aggregation-row-4027_2026-03-21-03-53.json
+++ b/common/changes/@visactor/vtable/fix-radio-aggregation-row-4027_2026-03-21-03-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix: radio cell should fallback to text in aggregation row",
+      "type": "patch",
+      "packageName": "@visactor/vtable"
+    }
+  ],
+  "packageName": "@visactor/vtable",
+  "email": "2779428708@qq.com"
+}

--- a/packages/vtable/src/scenegraph/group-creater/cell-helper.ts
+++ b/packages/vtable/src/scenegraph/group-creater/cell-helper.ts
@@ -423,25 +423,53 @@ export function createCell(
       );
     }
   } else if (type === 'radio') {
-    const createRadioCellGroup = Factory.getFunction('createRadioCellGroup') as CreateRadioCellGroup;
-    cellGroup = createRadioCellGroup(
-      null,
-      columnGroup,
-      0,
-      y,
-      col,
-      row,
-      colWidth,
-      cellWidth,
-      cellHeight,
-      padding,
-      textAlign,
-      textBaseline,
-      table,
-      cellTheme,
-      define as RadioColumnDefine,
-      range
-    );
+    const isAggregation =
+      'isAggregation' in table.internalProps.layoutMap && table.internalProps.layoutMap.isAggregation(col, row);
+    const isSeriesNumber = table.internalProps.layoutMap.isSeriesNumber(col, row);
+    if (isAggregation && isSeriesNumber) {
+      const createTextCellGroup = Factory.getFunction('createTextCellGroup') as CreateTextCellGroup;
+      cellGroup = createTextCellGroup(
+        table,
+        value,
+        columnGroup,
+        0,
+        y,
+        col,
+        row,
+        colWidth,
+        cellWidth,
+        cellHeight,
+        padding,
+        textAlign,
+        textBaseline,
+        false,
+        undefined,
+        true,
+        cellTheme,
+        range,
+        isAsync
+      );
+    } else {
+      const createRadioCellGroup = Factory.getFunction('createRadioCellGroup') as CreateRadioCellGroup;
+      cellGroup = createRadioCellGroup(
+        null,
+        columnGroup,
+        0,
+        y,
+        col,
+        row,
+        colWidth,
+        cellWidth,
+        cellHeight,
+        padding,
+        textAlign,
+        textBaseline,
+        table,
+        cellTheme,
+        define as RadioColumnDefine,
+        range
+      );
+    }
   } else if (type === 'switch') {
     const createSwitchCellGroup = Factory.getFunction('createSwitchCellGroup') as CreateSwitchCellGroup;
     cellGroup = createSwitchCellGroup(


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/VisActor/VTable/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link

close #4027

### 💡 Background and solution

When a table has aggregation rows and a column is configured with `cellType: 'radio'`, the radio button incorrectly appears in the aggregation row. However, `checkbox` type cells correctly fall back to plain text cells in the same scenario.

**Root cause:** In `packages/vtable/src/scenegraph/group-creater/cell-helper.ts`, the `checkbox` branch checks `isAggregation && isSeriesNumber` to decide whether to render a text cell instead of a checkbox, but the `radio` branch was missing this conditional check.

**Solution:** Added the same `isAggregation && isSeriesNumber` guard to the `radio` branch in `createCell()`. When the cell is in an aggregation row and is a series number column, it now renders as a plain text cell using `createTextCellGroup` instead of `createRadioCellGroup`, consistent with the checkbox behavior.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | fix: radio cell should fallback to text cell in aggregation row, consistent with checkbox behavior |
| 🇨🇳 Chinese | 修复：合计行中单选框(radio)单元格应降级为文本单元格，与复选框(checkbox)行为保持一致 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough