### PR TITLE
fix(table): radio cell should not render in summary row series number column #4027

### DIFF
--- a/packages/vtable/src/scenegraph/group-creater/cell-helper.ts
+++ b/packages/vtable/src/scenegraph/group-creater/cell-helper.ts
@@ -423,25 +423,54 @@ export function createCell(
       );
     }
   } else if (type === 'radio') {
-    const createRadioCellGroup = Factory.getFunction('createRadioCellGroup') as CreateRadioCellGroup;
-    cellGroup = createRadioCellGroup(
-      null,
-      columnGroup,
-      0,
-      y,
-      col,
-      row,
-      colWidth,
-      cellWidth,
-      cellHeight,
-      padding,
-      textAlign,
-      textBaseline,
-      table,
-      cellTheme,
-      define as RadioColumnDefine,
-      range
-    );
+    const isAggregation =
+      'isAggregation' in table.internalProps.layoutMap && table.internalProps.layoutMap.isAggregation(col, row);
+    const isSeriesNumber = table.internalProps.layoutMap.isSeriesNumber(col, row);
+    if (isAggregation && isSeriesNumber) {
+      // 合计行的行序号列不应渲染单选框，降级为普通文本单元格（与 checkbox 保持一致）
+      const createTextCellGroup = Factory.getFunction('createTextCellGroup') as CreateTextCellGroup;
+      cellGroup = createTextCellGroup(
+        table,
+        value,
+        columnGroup,
+        0,
+        y,
+        col,
+        row,
+        colWidth,
+        cellWidth,
+        cellHeight,
+        padding,
+        textAlign,
+        textBaseline,
+        false,
+        undefined,
+        true,
+        cellTheme,
+        range,
+        isAsync
+      );
+    } else {
+      const createRadioCellGroup = Factory.getFunction('createRadioCellGroup') as CreateRadioCellGroup;
+      cellGroup = createRadioCellGroup(
+        null,
+        columnGroup,
+        0,
+        y,
+        col,
+        row,
+        colWidth,
+        cellWidth,
+        cellHeight,
+        padding,
+        textAlign,
+        textBaseline,
+        table,
+        cellTheme,
+        define as RadioColumnDefine,
+        range
+      );
+    }
   } else if (type === 'switch') {
     const createSwitchCellGroup = Factory.getFunction('createSwitchCellGroup') as CreateSwitchCellGroup;
     cellGroup = createSwitchCellGroup(


### PR DESCRIPTION
## What

修复合计行（summary row）中行序号列（series number column）的单选框（radio）意外显示的问题。

## Why

Closes #4027

当表格配置了合计行且选择列为单选框类型时，合计行上会错误地渲染单选框，
而复选框类型已正确处理了这种情况（不显示）。两者行为不一致。

## How

在 `cell-helper.ts` 的 radio 分支中，仿照 checkbox 的处理方式，
添加 `isAggregation && isSeriesNumber` 判断：当处于合计行的序号列时，
降级渲染为普通文本单元格，与 checkbox 行为保持一致。

## Checklist
- [x] 逻辑修复，与 checkbox 分支处理完全对齐
- [x] 无破坏性变更（正常行中 radio 渲染逻辑不受影响）
