### PR TITLE
chore: update release ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,41 +292,39 @@ jobs:
         if: startsWith(github.ref_name, 'release/')
         run: node common/scripts/apply-release-version.js 'none' ${{ steps.semver_release.outputs.main }}
 
-      - name: Build vutils-extension && vtable
+      - name: Build packages
         env:
           NODE_OPTIONS: '--max_old_space_size=4096'
-        run: node common/scripts/install-run-rush.js build --to @visactor/vtable
+        run: |
+          set -euo pipefail
+          package_names=()
+          while IFS= read -r package_name; do
+            [ -n "$package_name" ] && package_names+=("$package_name")
+          done < <(node <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
 
-      - name: Build vtable-extension
-        if: startsWith(github.ref_name, 'release/') || startsWith(github.ref_name, 'pre-release/')
-        env:
-          NODE_OPTIONS: '--max_old_space_size=4096'
-        run: node common/scripts/install-run-rush.js build --only @visactor/vtable-extension
+          const packagesDir = path.join(process.cwd(), 'packages');
+          const packageNames = fs
+            .readdirSync(packagesDir, { withFileTypes: true })
+            .filter((entry) => entry.isDirectory())
+            .map((entry) => path.join(packagesDir, entry.name, 'package.json'))
+            .filter((packageJsonPath) => fs.existsSync(packageJsonPath))
+            .map((packageJsonPath) => JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')).name)
+            .filter(Boolean)
+            .sort();
 
-      - name: Build react-vtable
-        env:
-          NODE_OPTIONS: '--max_old_space_size=4096'
-        run: node common/scripts/install-run-rush.js build --only @visactor/react-vtable
+          console.log(packageNames.join('\n'));
+          NODE
+          )
 
-      - name: Build openinula-vtable
-        env:
-          NODE_OPTIONS: '--max_old_space_size=4096'
-        run: node common/scripts/install-run-rush.js build --only @visactor/openinula-vtable
+          build_args=()
+          for package_name in "${package_names[@]}"; do
+            build_args+=(--to "$package_name")
+          done
 
-      - name: Build taro-vtable
-        env:
-          NODE_OPTIONS: '--max_old_space_size=4096'
-        run: node common/scripts/install-run-rush.js build --only @visactor/taro-vtable
-
-      - name: Build lark-vtable
-        env:
-          NODE_OPTIONS: '--max_old_space_size=4096'
-        run: node common/scripts/install-run-rush.js build --only @visactor/lark-vtable
-
-      - name: Build wx-vtable
-        env:
-          NODE_OPTIONS: '--max_old_space_size=4096'
-        run: node common/scripts/install-run-rush.js build --only @visactor/wx-vtable
+          echo "Build packages: ${package_names[*]}"
+          node common/scripts/install-run-rush.js build "${build_args[@]}"
 
       - name: Publish to npm (release)
         if: startsWith(github.ref_name, 'release/')

--- a/common/scripts/apply-release-version.js
+++ b/common/scripts/apply-release-version.js
@@ -1,0 +1,19 @@
+const writePrereleaseVersion = require('./set-prerelease-version');
+const checkAndUpdateNextBump = require('./version-policies');
+const parseVersion = require('./parse-version');
+
+
+function run() {
+  const preReleaseName = process.argv.slice(2)[0];
+  const nextVersionOrNextBump = process.argv.slice(2)[1];
+  const buildName = process.argv.slice(2)[2];
+  const nextBump = checkAndUpdateNextBump(nextVersionOrNextBump);
+  const parsedNextVersion = nextVersionOrNextBump ? parseVersion(nextVersionOrNextBump) : null;
+  const nextVersion = parsedNextVersion ? `${parsedNextVersion.major}.${parsedNextVersion.minor}.${parsedNextVersion.patch}`: null;
+
+  console.log('[apply prerelease version]: ', preReleaseName, nextBump, nextVersion);
+
+  writePrereleaseVersion(nextBump, preReleaseName, nextVersion, buildName);
+}
+
+run()

--- a/packages/openinula-vtable/package.json
+++ b/packages/openinula-vtable/package.json
@@ -91,5 +91,10 @@
   },
   "peerDependencies": {
     "openinula": "~0.1.2-SNAPSHOT"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/VisActor/VTable.git",
+    "directory": "packages/openinula-vtable"
   }
 }

--- a/packages/react-vtable/package.json
+++ b/packages/react-vtable/package.json
@@ -110,5 +110,10 @@
     "@types/react-is": "^17.0.3",
     "@arco-design/web-react": "2.66.12",
     "@types/react-reconciler": "0.28.9"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/VisActor/VTable.git",
+    "directory": "packages/react-vtable"
   }
 }

--- a/packages/vtable-calendar/package.json
+++ b/packages/vtable-calendar/package.json
@@ -87,5 +87,10 @@
     "axios": "^1.4.0",
     "@types/react-is": "^17.0.3",
     "rollup-plugin-node-resolve": "5.2.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/VisActor/VTable.git",
+    "directory": "packages/vtable-calendar"
   }
 }

--- a/packages/vtable-export/package.json
+++ b/packages/vtable-export/package.json
@@ -90,5 +90,10 @@
     "axios": "^1.4.0",
     "@types/react-is": "^17.0.3",
     "rollup-plugin-node-resolve": "5.2.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/VisActor/VTable.git",
+    "directory": "packages/vtable-export"
   }
 }

--- a/packages/vtable-plugins/package.json
+++ b/packages/vtable-plugins/package.json
@@ -110,5 +110,10 @@
     "rollup-plugin-node-resolve": "5.2.0",
     "@types/lodash": "4.14.182"
   },
-  "packageManager": "pnpm@10.7.0"
+  "packageManager": "pnpm@10.7.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/VisActor/VTable.git",
+    "directory": "packages/vtable-plugins"
+  }
 }

--- a/packages/vtable-search/package.json
+++ b/packages/vtable-search/package.json
@@ -86,5 +86,10 @@
     "axios": "^1.4.0",
     "@types/react-is": "^17.0.3",
     "rollup-plugin-node-resolve": "5.2.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/VisActor/VTable.git",
+    "directory": "packages/vtable-search"
   }
 }

--- a/packages/vue-vtable/package.json
+++ b/packages/vue-vtable/package.json
@@ -107,5 +107,10 @@
     "axios": "^1.4.0",
     "eslint-plugin-vue": "^9.26.0",
     "vue-eslint-parser": "^9.4.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/VisActor/VTable.git",
+    "directory": "packages/vue-vtable"
   }
 }


### PR DESCRIPTION
## Summary
- replace hard-coded release build package steps with dynamic package discovery from `packages/*/package.json`
- remove stale build targets that no longer exist under `packages`
- keep the release workflow aligned with the current package set

## Validation
- checked workflow diagnostics
- verified generated rush build arguments locally
- ran the dynamic build command flow locally
