### PR TITLE
Fix/add row column plugin release error

### DIFF
--- a/common/changes/@visactor/vtable/fix-add-row-column-plugin-release-error_2026-05-17-02-59.json
+++ b/common/changes/@visactor/vtable/fix-add-row-column-plugin-release-error_2026-05-17-02-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix: add optional chaining in AddRowColumnPlugin release to prevent errors\n\n",
+      "type": "none",
+      "packageName": "@visactor/vtable"
+    }
+  ],
+  "packageName": "@visactor/vtable",
+  "email": "wangkyrin@gmail.com"
+}

--- a/packages/vtable-plugins/src/add-row-column.ts
+++ b/packages/vtable-plugins/src/add-row-column.ts
@@ -457,13 +457,13 @@ export class AddRowColumnPlugin implements pluginsDefinition.IVTablePlugin {
   }
   // #endregion
   release() {
-    this.leftDotForAddColumn.remove();
-    this.rightDotForAddColumn.remove();
-    this.addIconForAddColumn.remove();
-    this.addLineForAddColumn.remove();
-    this.topDotForAddRow.remove();
-    this.bottomDotForAddRow.remove();
-    this.addIconForAddRow.remove();
-    this.addLineForAddRow.remove();
+    this.leftDotForAddColumn?.remove();
+    this.rightDotForAddColumn?.remove();
+    this.addIconForAddColumn?.remove();
+    this.addLineForAddColumn?.remove();
+    this.topDotForAddRow?.remove();
+    this.bottomDotForAddRow?.remove();
+    this.addIconForAddRow?.remove();
+    this.addLineForAddRow?.remove();
   }
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/VTable/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link
fixed #5140
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution
AddRowColumnPlugin 的 release() 方法中直接调用了 this.leftDotForAddColumn.remove() 等 8 个 UI 元素的 remove() 方法。但这些 UI 元素（如 leftDotForAddColumn、rightDotForAddColumn、addIconForAddColumn 等）是在用户交互过程中懒创建的，如果插件在这些元素被创建之前就调用了 release()（例如初始化后直接销毁表格），这些属性为 undefined，导致抛出 Cannot read properties of undefined (reading 'remove') 错误。  

在 release() 方法中对所有 UI 元素的 remove() 调用添加可选链操作符 ?.，确保元素未初始化时安全跳过，不会抛出异常
<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   fix: add optional chaining in AddRowColumnPlugin release to prevent errors        |
| 🇨🇳 Chinese |   修复：AddRowColumnPlugin 的 release() 方法在 UI 元素未初始化时抛出空引用错误        |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
