### PR TITLE
fix: solve add row column plugin release issue #5140

### DIFF
--- a/common/changes/@visactor/vtable-plugins/fix-issue-5140-add-row-column-plugin-release_2026-05-25-17-05.json
+++ b/common/changes/@visactor/vtable-plugins/fix-issue-5140-add-row-column-plugin-release_2026-05-25-17-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@visactor/vtable-plugins",
+      "comment": "Fix an issue where `AddRowColumnPlugin.release()` threw when only row or column controls were enabled (GitHub #5140)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@visactor/vtable-plugins",
+  "email": "892739385@qq.com"
+}

--- a/packages/vtable-plugins/__tests__/add-row-column-plugin.test.ts
+++ b/packages/vtable-plugins/__tests__/add-row-column-plugin.test.ts
@@ -1,0 +1,47 @@
+// @ts-nocheck
+import { ListTable } from '@visactor/vtable';
+import { AddRowColumnPlugin } from '../src';
+import { createDiv } from '../../vtable/__tests__/dom';
+
+global.__VERSION__ = 'none';
+
+describe('AddRowColumnPlugin release - issue #5140', () => {
+  const columns = [
+    { field: 'id', title: 'ID', width: 120 },
+    { field: 'name', title: 'Name', width: 160 }
+  ];
+  const records = [
+    { id: 1, name: 'Alice' },
+    { id: 2, name: 'Bob' }
+  ];
+
+  function createTable(pluginOptions) {
+    const container = createDiv();
+    container.style.position = 'relative';
+    container.style.width = '600px';
+    container.style.height = '400px';
+
+    return new ListTable({
+      container,
+      columns,
+      records,
+      plugins: [new AddRowColumnPlugin(pluginOptions)]
+    });
+  }
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('release should not throw when row controls are disabled', () => {
+    const table = createTable({ addRowEnable: false });
+
+    expect(() => table.release()).not.toThrow();
+  });
+
+  test('release should not throw when column controls are disabled', () => {
+    const table = createTable({ addColumnEnable: false });
+
+    expect(() => table.release()).not.toThrow();
+  });
+});

--- a/packages/vtable-plugins/src/add-row-column.ts
+++ b/packages/vtable-plugins/src/add-row-column.ts
@@ -457,13 +457,13 @@ export class AddRowColumnPlugin implements pluginsDefinition.IVTablePlugin {
   }
   // #endregion
   release() {
-    this.leftDotForAddColumn.remove();
-    this.rightDotForAddColumn.remove();
-    this.addIconForAddColumn.remove();
-    this.addLineForAddColumn.remove();
-    this.topDotForAddRow.remove();
-    this.bottomDotForAddRow.remove();
-    this.addIconForAddRow.remove();
-    this.addLineForAddRow.remove();
+    this.leftDotForAddColumn?.remove();
+    this.rightDotForAddColumn?.remove();
+    this.addIconForAddColumn?.remove();
+    this.addLineForAddColumn?.remove();
+    this.topDotForAddRow?.remove();
+    this.bottomDotForAddRow?.remove();
+    this.addIconForAddRow?.remove();
+    this.addLineForAddRow?.remove();
   }
 }


### PR DESCRIPTION
## Summary
- fix `AddRowColumnPlugin.release()` so cleanup is safe when only row or only column controls are enabled
- add a focused regression test for releasing the plugin with partial controls enabled
- add a Rush change file for `@visactor/vtable-plugins`

## Verification
- inspect the plugin implementation path that calls `remove()` on optional DOM nodes
- verify diagnostics for edited files
- note: `pnpm -C packages/vtable-plugins test -- add-row-column-plugin.test.ts` is currently blocked by the existing Jest/ESM environment issue before the new test executes