### PR TITLE
fix: keep sheet multi-header record fields

### DIFF
--- a/packages/vtable-sheet/__tests__/formula-input-editor.test.ts
+++ b/packages/vtable-sheet/__tests__/formula-input-editor.test.ts
@@ -1,0 +1,38 @@
+// @ts-nocheck
+import { FormulaInputEditor } from '../src/formula/formula-editor';
+
+const createEditor = (formulaInput: HTMLInputElement | null = null) => {
+  const editor = new FormulaInputEditor();
+  const input = document.createElement('input');
+  input.value = 'updated value';
+
+  (editor as any).element = input;
+  (editor as any).sheet = {
+    formulaUIManager: {
+      formulaInput
+    },
+    formulaManager: {
+      cellHighlightManager: {
+        highlightFormulaCells: jest.fn(),
+        clearHighlights: jest.fn()
+      }
+    }
+  };
+
+  return { editor, input };
+};
+
+test('FormulaInputEditor does not throw when formula bar input is unavailable', () => {
+  const { editor } = createEditor(null);
+
+  expect(() => (editor as any).handleFormulaInput(new Event('input'))).not.toThrow();
+});
+
+test('FormulaInputEditor syncs cell editor input to formula bar when available', () => {
+  const formulaInput = document.createElement('input');
+  const { editor, input } = createEditor(formulaInput);
+
+  (editor as any).handleFormulaInput(new Event('input'));
+
+  expect(formulaInput.value).toBe(input.value);
+});

--- a/packages/vtable-sheet/__tests__/multi-header-record-data.test.ts
+++ b/packages/vtable-sheet/__tests__/multi-header-record-data.test.ts
@@ -1,0 +1,63 @@
+// @ts-nocheck
+import { VTableSheet } from '../src/index';
+import { createDiv, removeDom } from './dom';
+
+(global as any).__VERSION__ = 'none';
+
+test('VTableSheet keeps record fields when top-level columns mix leaf and grouped headers', () => {
+  const container = createDiv() as HTMLDivElement;
+  container.style.position = 'relative';
+  container.style.width = '1000px';
+  container.style.height = '800px';
+
+  const sheet = new VTableSheet(container, {
+    showFormulaBar: false,
+    showSheetTab: false,
+    defaultRowHeight: 25,
+    defaultColWidth: 100,
+    sheets: [
+      {
+        sheetKey: 'multiHeaderSheet',
+        sheetTitle: '多级表头示例',
+        active: true,
+        columns: [
+          { title: '计划编码', field: 'planningCode', width: 120 },
+          { title: '采购类别', field: 'type', width: 120 },
+          {
+            title: '采购需求计划完成时间',
+            columns: [
+              { title: '计划完成时间', field: 'demandPlanningTime', width: 150 },
+              { title: '实际完成时间', field: 'demandActualTime', width: 150 }
+            ]
+          },
+          { title: '备注', field: 'description', width: 120 }
+        ],
+        data: [
+          {
+            planningCode: 'PC-001',
+            type: 'type1-1',
+            demandPlanningTime: '2026-06-20',
+            demandActualTime: '2026-06-21',
+            description: 'record data'
+          }
+        ] as any
+      }
+    ]
+  });
+
+  try {
+    const table = sheet.getActiveSheet().tableInstance;
+    const dataRow = table.columnHeaderLevelCount;
+
+    expect(table.internalProps.layoutMap.getHeaderField(0, dataRow - 1)).toBe('planningCode');
+    expect(table.internalProps.layoutMap.getHeaderField(2, dataRow - 1)).toBe('demandPlanningTime');
+    expect(table.getCellValue(0, dataRow)).toBe('PC-001');
+    expect(table.getCellValue(1, dataRow)).toBe('type1-1');
+    expect(table.getCellValue(2, dataRow)).toBe('2026-06-20');
+    expect(table.getCellValue(3, dataRow)).toBe('2026-06-21');
+    expect(table.getCellValue(4, dataRow)).toBe('record data');
+  } finally {
+    sheet.release();
+    removeDom(container);
+  }
+});

--- a/packages/vtable-sheet/examples/menu.ts
+++ b/packages/vtable-sheet/examples/menu.ts
@@ -21,6 +21,10 @@ export const menus = [
   },
   {
     path: 'sheet',
+    name: 'issue-5184-multi-header'
+  },
+  {
+    path: 'sheet',
     name: 'history'
   }
 ];

--- a/packages/vtable-sheet/examples/sheet/issue-5184-multi-header.ts
+++ b/packages/vtable-sheet/examples/sheet/issue-5184-multi-header.ts
@@ -1,0 +1,125 @@
+import { VTableSheet } from '../../src/index';
+
+const CONTAINER_ID = 'vTable';
+
+const columns = [
+  { title: '计划编码', field: 'planningCode', width: 120 },
+  {
+    title: '采购类别',
+    field: 'type',
+    width: 120,
+    fieldFormat: (data: any) => {
+      const typeMap: Record<string, string> = {
+        'type1-1': '类型1-1',
+        'type1-2': '类型1-2',
+        'type1-2-1': '类型1-2-1',
+        'type1-2-2': '类型1-2-2',
+        type2: '类型2',
+        type3: '类型3'
+      };
+      return typeMap[data.type] || data.type;
+    }
+  },
+  { title: '责任人', field: 'personChargeName', width: 120 },
+  { title: '采购名称', field: 'procurementName', width: 120 },
+  {
+    title: '采购进度',
+    field: 'completeRate',
+    width: 180,
+    cellType: 'progressbar',
+    style: {
+      barColor: 'red',
+      barHeight: 24,
+      barBottom: 4,
+      textAlign: 'right'
+    },
+    fieldFormat: (data: any) => (data.completeRate ? `${data.completeRate}%` : '')
+  },
+  { title: '对外价格（不含税）', field: 'totalExternalPrice', width: 200 },
+  { title: '投标成本总价(不含税)', field: 'totalBidCost', width: 220 },
+  { title: '指导价/限价(不含税)', field: 'priceLimit', width: 220 },
+  {
+    title: '采购需求计划完成时间',
+    columns: [
+      { title: '计划完成时间', field: 'demandPlanningTime', width: 150 },
+      { title: '实际完成时间', field: 'demandActualTime', width: 150 }
+    ]
+  },
+  {
+    title: '采购谈判计划完成时间',
+    columns: [
+      { title: '计划完成时间', field: 'comparisonPlanningTime', width: 150 },
+      { title: '实际完成时间', field: 'comparisonActualTime', width: 150 }
+    ]
+  },
+  {
+    title: '合同签订计划完成时间',
+    columns: [
+      { title: '计划完成时间', field: 'contractPlanningTime', width: 150 },
+      { title: '实际完成时间', field: 'contractActualTime', width: 150 }
+    ]
+  },
+  { title: '签订合同金额（不含税）', field: 'contractNoTaxAmount', width: 220 },
+  { title: '签订合同金额（含税）', field: 'contractTaxAmount', width: 220 },
+  {
+    title: '成本偏差',
+    columns: [
+      { title: '对外(不含税)', field: 'actualTotalExternalPrice', width: 140 },
+      { title: '投标(不含税)', field: 'actualTotalBidCost', width: 140 },
+      { title: '指导价/限价(不含税)', field: 'actualPriceLimit', width: 200 }
+    ]
+  },
+  {
+    title: '盈亏率',
+    field: 'lossRate',
+    width: 120,
+    fieldFormat: (data: any) => `${data.lossRate}%`
+  },
+  { title: '合同编号', field: 'contractNum', width: 120 },
+  { title: '备注', field: 'description', width: 120 }
+];
+
+const data = Array.from({ length: 12 }, (_, index) => ({
+  planningCode: `PC-${String(index + 1).padStart(3, '0')}`,
+  type: index % 2 ? 'type2' : 'type1-1',
+  personChargeName: index % 2 ? '李四' : '张三',
+  procurementName: `采购项目${index + 1}`,
+  completeRate: 20 + index * 6,
+  totalExternalPrice: 100000 + index * 1000,
+  totalBidCost: 86000 + index * 800,
+  priceLimit: 120000 + index * 1200,
+  demandPlanningTime: '2026-06-20',
+  demandActualTime: '2026-06-21',
+  comparisonPlanningTime: '2026-06-25',
+  comparisonActualTime: '2026-06-26',
+  contractPlanningTime: '2026-07-01',
+  contractActualTime: '2026-07-02',
+  contractNoTaxAmount: 98000 + index * 900,
+  contractTaxAmount: 106000 + index * 950,
+  actualTotalExternalPrice: 1200 + index * 10,
+  actualTotalBidCost: 900 + index * 10,
+  actualPriceLimit: 1500 + index * 10,
+  lossRate: 8 + index,
+  contractNum: `HT-${String(index + 1).padStart(3, '0')}`,
+  description: `第 ${index + 1} 行`
+}));
+
+export function createTable() {
+  const container = document.getElementById(CONTAINER_ID)!;
+
+  window.sheetInstance = new VTableSheet(container, {
+    showFormulaBar: false,
+    showSheetTab: false,
+    defaultRowHeight: 32,
+    defaultColWidth: 120,
+    sheets: [
+      {
+        sheetKey: 'multiHeaderSheet',
+        sheetTitle: 'Issue 5184',
+        columns,
+        data: data as any,
+        active: true
+      }
+    ]
+  });
+}

--- a/packages/vtable-sheet/src/core/WorkSheet.ts
+++ b/packages/vtable-sheet/src/core/WorkSheet.ts
@@ -48,6 +48,34 @@ type WorkSheetUpdateOptions = Pick<
   theme?: TYPES.VTableThemes.ITableThemeDefine;
 };
 
+const normalizeColumnsField = (columns: IWorkSheetOptions['columns'], startFieldIndex = 0): number => {
+  if (!columns?.length) {
+    return startFieldIndex;
+  }
+
+  let fieldIndex = startFieldIndex;
+
+  columns.forEach(column => {
+    const childColumns = (column as IWorkSheetOptions['columns'][number] & { columns?: IWorkSheetOptions['columns'] })
+      .columns;
+
+    if (childColumns?.length) {
+      fieldIndex = normalizeColumnsField(childColumns, fieldIndex);
+      return;
+    }
+
+    if (!isValid(column.field)) {
+      column.field = fieldIndex;
+    }
+    if (!isValid(column.key)) {
+      column.key = column.field as any;
+    }
+    fieldIndex++;
+  });
+
+  return fieldIndex;
+};
+
 export class WorkSheet implements IWorkSheetAPI, IWorksheetEventSource {
   /** 选项 */
   options: IWorkSheetOptions;
@@ -274,10 +302,7 @@ export class WorkSheet implements IWorkSheetAPI, IWorksheetEventSource {
       isShowTableHeader = isValid(isShowTableHeader) ? isShowTableHeader : false;
       this.options.columns = [];
     } else {
-      for (let i = 0; i < this.options.columns.length; i++) {
-        this.options.columns[i].field = i;
-        this.options.columns[i].key = i as any;
-      }
+      normalizeColumnsField(this.options.columns);
     }
     if (!this.options.data) {
       this.options.data = [];

--- a/packages/vtable-sheet/src/formula/formula-editor.ts
+++ b/packages/vtable-sheet/src/formula/formula-editor.ts
@@ -17,7 +17,7 @@ export class FormulaInputEditor extends VTable_editors.InputEditor {
     return this.element;
   }
   targetIsOnEditor(target: HTMLElement): boolean {
-    return target === this.element || target === this.sheet.formulaUIManager.formulaInput;
+    return target === this.element || target === this.sheet?.formulaUIManager.formulaInput;
   }
   /**
    * 创建编辑器元素
@@ -65,7 +65,10 @@ export class FormulaInputEditor extends VTable_editors.InputEditor {
 
     const value = this.element.value;
     // 同步内容到顶部输入栏
-    this.sheet.formulaUIManager.formulaInput.value = value;
+    const formulaInput = this.sheet.formulaUIManager.formulaInput;
+    if (formulaInput) {
+      formulaInput.value = value;
+    }
     // const inputEvent = new Event('input', { bubbles: true });
     // Object.defineProperty(inputEvent, 'isFormulaInsertion', { value: true });
     // this.sheet.formulaUIManager.formulaInput.dispatchEvent(inputEvent);


### PR DESCRIPTION
## Summary
- fix VTableSheet column normalization so mixed leaf/grouped headers preserve user-defined record fields
- add an issue 5184 reproduction demo for multi-level headers with record data
- add a regression test covering mixed top-level leaf and grouped columns

Fixes #5184

## Tests
- rushx test --runInBand multi-header-record-data.test.ts
- rushx compile
- rushx test --runInBand
- git diff --check