### PR TITLE
fix: handle scroll frozen columns width

### DIFF
--- a/common/changes/@visactor/vtable/codex-fix-issue-5187-max-frozen-width_2026-06-23-08-46.json
+++ b/common/changes/@visactor/vtable/codex-fix-issue-5187-max-frozen-width_2026-06-23-08-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix: handle scroll frozen columns width",
+      "type": "patch",
+      "packageName": "@visactor/vtable"
+    }
+  ],
+  "packageName": "@visactor/vtable",
+  "email": "892739385@qq.com"
+}

--- a/packages/vtable/__tests__/options/listTable-scroll-frozen-cols.test.ts
+++ b/packages/vtable/__tests__/options/listTable-scroll-frozen-cols.test.ts
@@ -1,0 +1,84 @@
+// @ts-nocheck
+import { ListTable } from '../../src';
+import { createDiv } from '../dom';
+
+global.__VERSION__ = 'none';
+
+describe('listTable scroll frozen columns', () => {
+  test('keeps body next to frozen viewport when horizontal layout tries to shift right', () => {
+    const containerDom: HTMLElement = createDiv();
+    containerDom.style.position = 'relative';
+    containerDom.style.width = '1055px';
+    containerDom.style.height = '520px';
+
+    const columns = [
+      ['orderDate', '订单日期', 91],
+      ['customerName', '客户名称', 76],
+      ['shipDate', '发货日期', 91],
+      ['deliveryDate', '交付日期', 91],
+      ['productDate', '产品日期', 91],
+      ['category', '类别', 76],
+      ['subCategory', '子类别', 76],
+      ['region', '区域', 76],
+      ['customerId', '客户编号', 110],
+      ['birthDate', '出生日期', 100],
+      ['renewDate', '续费日期', 100],
+      ['rate', '折扣', 76],
+      ['ratio', '占比', 76]
+    ].map(([field, title, width]) => ({
+      field,
+      title,
+      width
+    }));
+    const records = Array.from({ length: 20 }, (_, index) => ({
+      orderDate: `2016-01-${index + 1}`,
+      customerName: `客户${index + 1}`,
+      shipDate: `2016-02-${index + 1}`,
+      deliveryDate: `2017-05-${index + 1}`,
+      productDate: `2016-03-${index + 1}`,
+      category: '家具',
+      subCategory: '桌子',
+      region: '中南',
+      customerId: `customer-${index + 1}`,
+      birthDate: '1975-07-10',
+      renewDate: '2026-02-28',
+      rate: `${(index % 5) / 10}`,
+      ratio: `${(index % 4) / 4}`
+    }));
+
+    const listTable = new ListTable(containerDom, {
+      columns,
+      records,
+      frozenColCount: 4,
+      maxFrozenWidth: 100,
+      unfreezeAllOnExceedsMaxWidth: false,
+      scrollFrozenCols: true
+    });
+
+    expect(listTable.getFrozenColsWidth()).toBe(100);
+    expect(listTable.getFrozenColsContentWidth()).toBeGreaterThan(100);
+
+    listTable.scenegraph.updateTableSize();
+    expect(listTable.scenegraph.cornerHeaderGroup.attribute.width).toBe(100);
+    expect(listTable.scenegraph.rowHeaderGroup.attribute.width).toBe(100);
+
+    listTable.scenegraph.setBodyAndColHeaderX(172);
+    expect(listTable.scenegraph.bodyGroup.attribute.x).toBe(100);
+    expect(listTable.scenegraph.colHeaderGroup.attribute.x).toBe(100);
+
+    listTable.scenegraph.component.updateScrollBar();
+    expect(listTable.scenegraph.component.hScrollBar.attribute.visible).toBe(false);
+    expect(listTable.scenegraph.component.hScrollBar.attribute.width).toBe(0);
+    expect(listTable.scenegraph.component.frozenHScrollBar.attribute.width).toBe(100);
+    expect(listTable.scenegraph.component.frozenHScrollBar.attribute.range[1]).toBeLessThan(1);
+
+    listTable.scenegraph.component.showHorizontalScrollBar('all');
+    expect(listTable.scenegraph.component.hScrollBar.attribute.visible).toBe(false);
+    expect(listTable.scenegraph.component.frozenHScrollBar.attribute.visible).toBe(true);
+
+    listTable.setScrollLeft(100);
+    expect(listTable.scrollLeft).toBe(0);
+
+    listTable.release();
+  });
+});

--- a/packages/vtable/examples/debug/issue-5187-max-frozen-width.ts
+++ b/packages/vtable/examples/debug/issue-5187-max-frozen-width.ts
@@ -1,0 +1,141 @@
+import * as VTable from '../../src';
+
+const CONTAINER_ID = 'vTable';
+
+const fields = [
+  ['orderDate', '订单日期', 91],
+  ['customerName', '客户名称', 76],
+  ['shipDate', '发货日期', 91],
+  ['deliveryDate', '交付日期', 91],
+  ['productDate', '产品日期', 91],
+  ['category', '类别', 76],
+  ['subCategory', '子类别', 76],
+  ['region', '区域', 76],
+  ['customerId', '客户编号', 110],
+  ['birthDate', '出生日期', 100],
+  ['renewDate', '续费日期', 100],
+  ['rate', '折扣', 76],
+  ['ratio', '占比', 76]
+] as const;
+
+const records = Array.from({ length: 80 }, (_, index) => {
+  const day = `${(index % 28) + 1}`.padStart(2, '0');
+  const names = ['邢宁', '俞毅', '麦虢', '牛惠', '陶丽雪', '徐虹'];
+
+  return {
+    orderDate: `2016-01-${day}`,
+    customerName: names[index % names.length],
+    shipDate: `2016-02-${day}`,
+    deliveryDate: `2017-05-${day}`,
+    productDate: `2016-03-${day}`,
+    category: ['家具', '技术', '办公用品'][index % 3],
+    subCategory: ['桌子', '电话', '配件', '收纳具'][index % 4],
+    region: index % 2 ? '分组1' : '中南',
+    customerId: `${names[index % names.length]}-${10000 + index}`,
+    birthDate: '1975-07-10',
+    renewDate: '2026-02-28',
+    rate: `${(index % 5) / 10}`,
+    ratio: `${(index % 4) / 4}`
+  };
+});
+
+export function createTable() {
+  const container = document.getElementById(CONTAINER_ID)!;
+  document.getElementById('issue5187Toolbar')?.remove();
+
+  container.style.width = '640px';
+  container.style.height = '520px';
+
+  const toolbar = document.createElement('div');
+  toolbar.id = 'issue5187Toolbar';
+  toolbar.style.cssText = 'height: 32px; display: flex; gap: 8px; align-items: center; font-size: 12px;';
+  toolbar.innerHTML = `
+    <button id="issue5187ScrollFrozen">scroll frozen cols</button>
+    <button id="issue5187Wide">set container 1600px</button>
+    <button id="issue5187Narrow">set container 1055px</button>
+    <button id="issue5187Reproduce">reproduce 1600px -> 1055px</button>
+    <span id="issue5187State"></span>
+  `;
+  container.before(toolbar);
+
+  const columns: VTable.ColumnsDefine = fields.map(([field, title, width]) => ({
+    field,
+    title,
+    width,
+    showSort: false
+  }));
+
+  const tableInstance = new VTable.ListTable({
+    container,
+    columns,
+    records,
+    widthMode: 'standard',
+    columnResizeMode: 'all',
+    defaultRowHeight: 35.2,
+    heightMode: 'autoHeight',
+    defaultHeaderColWidth: 'auto',
+    frozenColCount: 4,
+    maxFrozenWidth: 100,
+    unfreezeAllOnExceedsMaxWidth: false,
+    scrollFrozenCols: true,
+    theme: VTable.themes.DEFAULT.extends({
+      scrollStyle: {
+        visible: 'focus',
+        width: 7,
+        hoverOn: true
+      },
+      frozenColumnLine: {
+        shadow: {
+          width: 3,
+          startColor: 'rgba(225, 228, 232, 0.6)',
+          endColor: 'rgba(225, 228, 232, 0.6)'
+        }
+      }
+    })
+  });
+
+  const stateNode = document.getElementById('issue5187State')!;
+  const updateState = () => {
+    stateNode.textContent = [
+      `container: ${container.style.width}`,
+      `frozen width: ${tableInstance.getFrozenColsWidth()}`,
+      `content: ${tableInstance.getFrozenColsContentWidth()}`,
+      `offset: ${tableInstance.getFrozenColsOffset()}`,
+      `scrollLeft: ${tableInstance.getFrozenColsScrollLeft()}`
+    ].join(' | ');
+  };
+  const resizeContainer = (width: number) => {
+    container.style.width = `${width}px`;
+    tableInstance.resize();
+    updateState();
+  };
+
+  document.getElementById('issue5187ScrollFrozen')?.addEventListener('click', () => {
+    tableInstance.stateManager.setFrozenColsScrollLeft(tableInstance.getFrozenColsOffset());
+    updateState();
+  });
+  document.getElementById('issue5187Wide')?.addEventListener('click', () => {
+    resizeContainer(1600);
+  });
+  document.getElementById('issue5187Narrow')?.addEventListener('click', () => {
+    resizeContainer(1055);
+  });
+  document.getElementById('issue5187Reproduce')?.addEventListener('click', () => {
+    resizeContainer(1600);
+    tableInstance.stateManager.setFrozenColsScrollLeft(tableInstance.getFrozenColsOffset());
+    requestAnimationFrame(() => {
+      resizeContainer(1055);
+    });
+  });
+
+  tableInstance.on(VTable.ListTable.EVENT_TYPE.RESIZE_COLUMN_END, updateState);
+  updateState();
+
+  const release = tableInstance.release.bind(tableInstance);
+  tableInstance.release = () => {
+    document.getElementById('issue5187Toolbar')?.remove();
+    release();
+  };
+
+  (window as any).tableInstance = tableInstance;
+}

--- a/packages/vtable/examples/menu.ts
+++ b/packages/vtable/examples/menu.ts
@@ -45,6 +45,10 @@ export const menus = [
       {
         path: 'debug',
         name: 'scroll-collapse-bottom'
+      },
+      {
+        path: 'debug',
+        name: 'issue-5187-max-frozen-width'
       }
     ]
   },

--- a/packages/vtable/src/scenegraph/component/table-component.ts
+++ b/packages/vtable/src/scenegraph/component/table-component.ts
@@ -6,7 +6,7 @@ import type { Group } from '../graphic/group';
 import { MenuHandler } from './menu';
 import { DrillIcon } from './drill-icon';
 import { CellMover } from './cell-mover';
-import { getColX, getRowY } from './util';
+import { getBodyHorizontalScrollRange, getColX, getRowY } from './util';
 import type { BaseTableAPI } from '../../ts-types/base-table';
 import { isValid } from '@visactor/vutils';
 
@@ -416,31 +416,31 @@ export class TableComponent {
     // 这里加入tolerance，避免出现无用滚动
     const sizeTolerance = this.table.options.customConfig?._disableColumnAndRowSizeRound ? 1 : 0;
 
-    if (totalWidth > tableWidth + sizeTolerance) {
-      const y = Math.min(tableHeight, totalHeight);
+    const bodyScrollRange = getBodyHorizontalScrollRange(this.table);
+    const y = Math.min(tableHeight, totalHeight);
+    let attrY = 0;
+    if (this.table.theme.scrollStyle.barToSide) {
+      attrY =
+        this.table.tableNoFrameHeight -
+        (hoverOn ? width : -this.table.scenegraph.tableGroup.attribute.y) +
+        this.table.tableY;
+    } else {
+      attrY = y - (hoverOn ? width : -this.table.scenegraph.tableGroup.attribute.y);
+    }
+    // 忽略所有冻结列宽度
+    const ignoreFrozenCols = this.table.theme.scrollStyle?.ignoreFrozenCols ?? false;
+
+    if (bodyScrollRange > sizeTolerance) {
       // 多滚动域下，body 的可视区域需要扣除左右冻结占用的视口宽度；
       // body 的可滚动内容宽度也需要扣除左右冻结列的内容宽度。
       // 这样主滚动条的滑块长度能准确反映“body 可视宽 / body 内容宽”的比例。
       const bodyViewportWidth = tableWidth - frozenColsWidth - rightFrozenColsWidth;
-      const bodyContentWidth = totalWidth - frozenColsContentWidth - rightFrozenColsContentWidth;
+      const bodyContentWidth = bodyViewportWidth + bodyScrollRange;
       const rangeEnd = bodyContentWidth > 0 ? Math.max(0.05, bodyViewportWidth / bodyContentWidth) : 1;
-
-      let attrY = 0;
-      if (this.table.theme.scrollStyle.barToSide) {
-        attrY =
-          this.table.tableNoFrameHeight -
-          (hoverOn ? width : -this.table.scenegraph.tableGroup.attribute.y) +
-          this.table.tableY;
-      } else {
-        attrY = y - (hoverOn ? width : -this.table.scenegraph.tableGroup.attribute.y);
-      }
 
       let hScrollBarx = frozenColsWidth + (!hoverOn ? this.table.scenegraph.tableGroup.attribute.x : 0);
 
       let hScrollBarWidth = tableWidth - frozenColsWidth - rightFrozenColsWidth;
-
-      // 忽略所有冻结列宽度
-      const ignoreFrozenCols = this.table.theme.scrollStyle?.ignoreFrozenCols ?? false;
 
       if (ignoreFrozenCols) {
         hScrollBarx = !hoverOn ? this.table.scenegraph.tableGroup.attribute.x : 0;
@@ -465,65 +465,6 @@ export class TableComponent {
       if (horizontalVisible === 'always') {
         this.hScrollBar.showAll();
       }
-
-      const frozenScrollable = this.table.options.scrollFrozenCols && this.table.getFrozenColsOffset() > 0;
-      if (!ignoreFrozenCols && frozenScrollable) {
-        // 左冻结滚动条的滑块长度 = 冻结视口宽 / 冻结内容宽
-        const frozenRangeEnd = Math.max(0.05, frozenColsWidth / frozenColsContentWidth);
-        const x = !hoverOn ? this.table.scenegraph.tableGroup.attribute.x : 0;
-        this.frozenHScrollBar.setAttributes({
-          x,
-          y: attrY,
-          width: frozenColsWidth,
-          range: [0, frozenRangeEnd],
-          visible: horizontalVisible === 'always'
-        });
-        const bounds = this.frozenHScrollBar.AABBBounds && this.frozenHScrollBar.globalAABBBounds;
-        (this.frozenHScrollBar as any)._viewPosition = {
-          x: bounds.x1,
-          y: bounds.y1
-        };
-        if (horizontalVisible === 'always') {
-          this.frozenHScrollBar.showAll();
-        }
-      } else {
-        this.frozenHScrollBar.setAttributes({
-          x: -this.table.tableNoFrameWidth * 2,
-          y: -this.table.tableNoFrameHeight * 2,
-          width: 0,
-          visible: false
-        });
-      }
-
-      const rightFrozenScrollable =
-        this.table.options.scrollRightFrozenCols && this.table.getRightFrozenColsOffset() > 0;
-      if (!ignoreFrozenCols && rightFrozenScrollable) {
-        // 右冻结滚动条的滑块长度 = 右冻结视口宽 / 右冻结内容宽
-        const rightFrozenRangeEnd = Math.max(0.05, rightFrozenColsWidth / rightFrozenColsContentWidth);
-        const x = tableWidth - rightFrozenColsWidth + (!hoverOn ? this.table.scenegraph.tableGroup.attribute.x : 0);
-        this.rightFrozenHScrollBar.setAttributes({
-          x,
-          y: attrY,
-          width: rightFrozenColsWidth,
-          range: [0, rightFrozenRangeEnd],
-          visible: horizontalVisible === 'always'
-        });
-        const bounds = this.rightFrozenHScrollBar.AABBBounds && this.rightFrozenHScrollBar.globalAABBBounds;
-        (this.rightFrozenHScrollBar as any)._viewPosition = {
-          x: bounds.x1,
-          y: bounds.y1
-        };
-        if (horizontalVisible === 'always') {
-          this.rightFrozenHScrollBar.showAll();
-        }
-      } else {
-        this.rightFrozenHScrollBar.setAttributes({
-          x: -this.table.tableNoFrameWidth * 2,
-          y: -this.table.tableNoFrameHeight * 2,
-          width: 0,
-          visible: false
-        });
-      }
     } else {
       this.hScrollBar.setAttributes({
         x: -this.table.tableNoFrameWidth * 2,
@@ -531,12 +472,59 @@ export class TableComponent {
         width: 0,
         visible: false
       });
+    }
+
+    const frozenScrollable = this.table.options.scrollFrozenCols && this.table.getFrozenColsOffset() > 0;
+    if (!ignoreFrozenCols && frozenScrollable) {
+      // 左冻结滚动条的滑块长度 = 冻结视口宽 / 冻结内容宽
+      const frozenRangeEnd = Math.max(0.05, frozenColsWidth / frozenColsContentWidth);
+      const x = !hoverOn ? this.table.scenegraph.tableGroup.attribute.x : 0;
+      this.frozenHScrollBar.setAttributes({
+        x,
+        y: attrY,
+        width: frozenColsWidth,
+        range: [0, frozenRangeEnd],
+        visible: horizontalVisible === 'always'
+      });
+      const bounds = this.frozenHScrollBar.AABBBounds && this.frozenHScrollBar.globalAABBBounds;
+      (this.frozenHScrollBar as any)._viewPosition = {
+        x: bounds.x1,
+        y: bounds.y1
+      };
+      if (horizontalVisible === 'always') {
+        this.frozenHScrollBar.showAll();
+      }
+    } else {
       this.frozenHScrollBar.setAttributes({
         x: -this.table.tableNoFrameWidth * 2,
         y: -this.table.tableNoFrameHeight * 2,
         width: 0,
         visible: false
       });
+    }
+
+    const rightFrozenScrollable =
+      this.table.options.scrollRightFrozenCols && this.table.getRightFrozenColsOffset() > 0;
+    if (!ignoreFrozenCols && rightFrozenScrollable) {
+      // 右冻结滚动条的滑块长度 = 右冻结视口宽 / 右冻结内容宽
+      const rightFrozenRangeEnd = Math.max(0.05, rightFrozenColsWidth / rightFrozenColsContentWidth);
+      const x = tableWidth - rightFrozenColsWidth + (!hoverOn ? this.table.scenegraph.tableGroup.attribute.x : 0);
+      this.rightFrozenHScrollBar.setAttributes({
+        x,
+        y: attrY,
+        width: rightFrozenColsWidth,
+        range: [0, rightFrozenRangeEnd],
+        visible: horizontalVisible === 'always'
+      });
+      const bounds = this.rightFrozenHScrollBar.AABBBounds && this.rightFrozenHScrollBar.globalAABBBounds;
+      (this.rightFrozenHScrollBar as any)._viewPosition = {
+        x: bounds.x1,
+        y: bounds.y1
+      };
+      if (horizontalVisible === 'always') {
+        this.rightFrozenHScrollBar.showAll();
+      }
+    } else {
       this.rightFrozenHScrollBar.setAttributes({
         x: -this.table.tableNoFrameWidth * 2,
         y: -this.table.tableNoFrameHeight * 2,

--- a/packages/vtable/src/scenegraph/component/util.ts
+++ b/packages/vtable/src/scenegraph/component/util.ts
@@ -1,5 +1,17 @@
 import type { BaseTableAPI } from '../../ts-types/base-table';
 
+export function getBodyHorizontalScrollRange(table: BaseTableAPI) {
+  const totalWidth = table.getAllColsWidth();
+  const frozenColsWidth = table.getFrozenColsWidth();
+  const rightFrozenColsWidth = table.getRightFrozenColsWidth();
+  const frozenColsContentWidth = table.getFrozenColsContentWidth?.() ?? frozenColsWidth;
+  const rightFrozenColsContentWidth = table.getRightFrozenColsContentWidth?.() ?? rightFrozenColsWidth;
+  const bodyViewportWidth = table.tableNoFrameWidth - frozenColsWidth - rightFrozenColsWidth;
+  const bodyContentWidth = totalWidth - frozenColsContentWidth - rightFrozenColsContentWidth;
+
+  return Math.max(0, bodyContentWidth - bodyViewportWidth);
+}
+
 export function getColX(col: number, table: BaseTableAPI, isRightFrozen?: boolean) {
   if (isRightFrozen) {
     // 右冻结列的 x 位置以“表格最右侧”为基准向左累加。

--- a/packages/vtable/src/scenegraph/scenegraph.ts
+++ b/packages/vtable/src/scenegraph/scenegraph.ts
@@ -1638,6 +1638,9 @@ export class Scenegraph {
         lastBodyCol.attribute.x -
         lastBodyCol.attribute.width;
     }
+    if (this.table.options.scrollFrozenCols && x > 0) {
+      x = 0;
+    }
     if (this.table.getFrozenColsWidth() + x === this.bodyGroup.attribute.x) {
       return;
     }
@@ -1795,11 +1798,17 @@ export class Scenegraph {
     this.rowHeaderGroup.forEachChildrenSkipChild((column: Group) => {
       rowHeaderWidth += column.attribute.width;
     });
+    if (table.options.scrollFrozenCols) {
+      rowHeaderWidth = table.getFrozenColsWidth();
+    }
     this.rowHeaderGroup.setAttribute('width', rowHeaderWidth);
     let cornerHeaderWidth = 0;
     this.cornerHeaderGroup.forEachChildrenSkipChild((column: Group) => {
       cornerHeaderWidth += column.attribute.width;
     });
+    if (table.options.scrollFrozenCols) {
+      cornerHeaderWidth = table.getFrozenColsWidth();
+    }
     this.cornerHeaderGroup.setAttribute('width', cornerHeaderWidth);
     this.colHeaderGroup.setAttribute('x', this.cornerHeaderGroup.attribute.width);
     this.rowHeaderGroup.setAttribute('y', this.cornerHeaderGroup.attribute.height);

--- a/packages/vtable/src/state/state.ts
+++ b/packages/vtable/src/state/state.ts
@@ -35,6 +35,7 @@ import type { FederatedWheelEvent, IRectGraphicAttribute } from '@src/vrender';
 import type { TooltipOptions } from '../ts-types/tooltip';
 import { getIconAndPositionFromTarget } from '../scenegraph/utils/icon';
 import type { BaseTableAPI, HeaderData } from '../ts-types/base-table';
+import { getBodyHorizontalScrollRange } from '../scenegraph/component/util';
 import { debounce } from '../tools/debounce';
 import { updateResizeColumn } from './resize/update-resize-column';
 import { changeRadioOrder, setRadioState, syncRadioState } from './radio/radio';
@@ -1215,11 +1216,8 @@ export class StateManager {
     }
   }
   updateHorizontalScrollBar(xRatio: number) {
-    const totalWidth = this.table.getAllColsWidth();
     const oldHorizontalBarPos = this.scroll.horizontalBarPos;
-    const frozenOffset = this.table.getFrozenColsOffset?.() ?? 0;
-    const rightFrozenOffset = this.table.getRightFrozenColsOffset?.() ?? 0;
-    const scrollRange = Math.max(0, totalWidth - this.table.scenegraph.width - frozenOffset - rightFrozenOffset);
+    const scrollRange = getBodyHorizontalScrollRange(this.table);
 
     let horizontalBarPos = Math.ceil(xRatio * scrollRange);
     if (!isValid(horizontalBarPos) || isNaN(horizontalBarPos)) {
@@ -1368,10 +1366,7 @@ export class StateManager {
     }
     const oldScrollLeft = this.table.scrollLeft;
     // 矫正left值范围
-    const totalWidth = this.table.getAllColsWidth();
-    const frozenOffset = this.table.getFrozenColsOffset?.() ?? 0;
-    const rightFrozenOffset = this.table.getRightFrozenColsOffset?.() ?? 0;
-    const scrollRange = Math.max(0, totalWidth - this.table.scenegraph.width - frozenOffset - rightFrozenOffset);
+    const scrollRange = getBodyHorizontalScrollRange(this.table);
 
     // _disableColumnAndRowSizeRound环境中，可能出现
     // getAllColsWidth/getAllRowsHeight(A) + getAllColsWidth/getAllRowsHeight(B) < getAllColsWidth/getAllRowsHeight(A+B)


### PR DESCRIPTION
## Summary
- fix body layout positioning when scrollFrozenCols limits frozen columns by maxFrozenWidth
- keep body horizontal scrollbar hidden when all body columns fit while preserving frozen-area scrolling
- add an issue 5187 debug demo and regression coverage

## Tests
- npx jest __tests__/options/listTable-scroll-frozen-cols.test.ts --runInBand
- npm run compile

Fixes #5187