### PR TITLE
Fix/issue 5088 carousel fractional row

### DIFF
--- a/common/changes/@visactor/vtable/fix-issue-5088-carousel-fractional-row_2026-06-23-10-48.json
+++ b/common/changes/@visactor/vtable/fix-issue-5088-carousel-fractional-row_2026-06-23-10-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix: keep fractional row scroll target",
+      "type": "none",
+      "packageName": "@visactor/vtable"
+    }
+  ],
+  "packageName": "@visactor/vtable",
+  "email": "biukam.w@gmail.com"
+}

--- a/packages/vtable/__tests__/api/listTable-scrollToRow.test.ts
+++ b/packages/vtable/__tests__/api/listTable-scrollToRow.test.ts
@@ -1,0 +1,36 @@
+// @ts-nocheck
+import { ListTable } from '../../src';
+import { createDiv } from '../dom';
+
+global.__VERSION__ = 'none';
+
+describe('listTable scrollToRow api', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  test('keeps fractional row target when scrolling with animation', () => {
+    const container = createDiv();
+    container.style.position = 'relative';
+    container.style.width = '400px';
+    container.style.height = '240px';
+
+    const table = new ListTable({
+      container,
+      columns: [{ field: 'name', title: 'Name', width: 120 }],
+      records: Array.from({ length: 20 }, (_, index) => ({ name: `row-${index}` })),
+      defaultRowHeight: 40
+    });
+
+    const scrollTo = jest.spyOn(table.animationManager, 'scrollTo').mockImplementation(() => undefined);
+    const setTimeoutSpy = jest.spyOn(globalThis, 'setTimeout').mockImplementation(() => 0 as any);
+
+    table.scrollToRow(1.5, { duration: 100, easing: 'linear' });
+
+    expect(scrollTo).toHaveBeenCalledWith({ row: 1.5 }, { duration: 100, easing: 'linear' });
+    expect(setTimeoutSpy).not.toHaveBeenCalled();
+
+    table.release();
+  });
+});

--- a/packages/vtable/src/core/BaseTable.ts
+++ b/packages/vtable/src/core/BaseTable.ts
@@ -5275,18 +5275,21 @@ export abstract class BaseTable extends EventTarget implements BaseTableAPI {
 
   // anmiation
   scrollToRow(row: number, animationOption?: ITableAnimationOption | boolean) {
-    const targetRow = Math.min(Math.max(Math.floor(row), 0), this.rowCount - 1);
+    const targetRow = Math.min(Math.max(row, 0), this.rowCount - 1);
+    const targetRowInt = Math.floor(targetRow);
     this.clearCorrectTimer();
     if (!animationOption) {
-      this.scrollToCell({ row: targetRow });
-      this._scheduleScrollToRowCorrect(targetRow);
+      this.scrollToCell({ row: targetRowInt });
+      this._scheduleScrollToRowCorrect(targetRowInt);
       return;
     }
     const duration = !isBoolean(animationOption) ? animationOption?.duration ?? 3000 : 3000;
     this.animationManager.scrollTo({ row: targetRow }, animationOption);
-    this._scrollToRowCorrectTimer = setTimeout(() => {
-      this.scrollToRow(targetRow, false);
-    }, duration);
+    if (targetRowInt === targetRow) {
+      this._scrollToRowCorrectTimer = setTimeout(() => {
+        this.scrollToRow(targetRowInt, false);
+      }, duration);
+    }
   }
   scrollToCol(col: number, animationOption?: ITableAnimationOption | boolean) {
     if (!animationOption) {


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link

fix #5088

### 💡 Background and solution

When `TableCarouselAnimationPlugin` uses a fractional row step such as `rowCount: 1.5`, the animated scroll target should preserve the fractional row offset. However, `scrollToRow` rounded the target row down before starting the animation, and the post-animation correction also snapped the final scroll position back to an integer row. This caused fractional carousel scrolling to behave incorrectly.

This change keeps fractional row targets for animated `scrollToRow` calls and only applies the post-animation integer correction when the requested row is already an integer. Non-animated `scrollToRow` calls still align to an integer row.

A regression test was added for `scrollToRow(1.5, animationOption)` to ensure the fractional target is passed to the animation manager without scheduling an integer snap-back.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix animated fractional row scrolling snapping back to integer rows. |
| 🇨🇳 Chinese | 修复带动画的小数行滚动会被强制对齐到整数行的问题。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough