### PR TITLE
fix: skip click cell after resize

### DIFF
--- a/common/changes/@visactor/vtable/codex-fix-issue-5186-skip-click-after-resize_2026-06-24-16-11.json
+++ b/common/changes/@visactor/vtable/codex-fix-issue-5186-skip-click-after-resize_2026-06-24-16-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix: skip click cell after resize interaction ends",
+      "type": "patch",
+      "packageName": "@visactor/vtable"
+    }
+  ],
+  "packageName": "@visactor/vtable",
+  "email": "892739385@qq.com"
+}

--- a/packages/vtable/src/event/listener/table-group.ts
+++ b/packages/vtable/src/event/listener/table-group.ts
@@ -617,15 +617,20 @@ export function bindTableGroupListener(eventManager: EventManager) {
       // 只处理左键
       return;
     }
+    const endedResizeCol = stateManager.isResizeCol();
+    const endedResizeRow = stateManager.isResizeRow();
+    const endedMoveCol = stateManager.isMoveCol();
+    const endedDragSelect = stateManager.isSelecting() && table.eventManager.isDraging;
+    const shouldSkipClickCell = endedResizeCol || endedResizeRow || endedMoveCol || endedDragSelect;
     if (stateManager.interactionState === 'grabing') {
       // stateManager.interactionState = 'default';
       stateManager.updateInteractionState(InteractionState.default);
       // eventManager._resizing = false;
-      if (stateManager.isResizeCol()) {
+      if (endedResizeCol) {
         endResizeCol(table);
-      } else if (stateManager.isResizeRow()) {
+      } else if (endedResizeRow) {
         endResizeRow(table);
-      } else if (stateManager.isMoveCol()) {
+      } else if (endedMoveCol) {
         // const eventArgsSet: SceneEvent = getCellEventArgsSet(e);
         const endMoveColSuccess = table.stateManager.endMoveCol();
         fireMoveColEventListeners(table, endMoveColSuccess, e.nativeEvent);
@@ -658,7 +663,7 @@ export function bindTableGroupListener(eventManager: EventManager) {
       stateManager.updateInteractionState(InteractionState.default);
       // scroll end
     }
-    if (!table.eventManager.isDraging) {
+    if (!table.eventManager.isDraging && !shouldSkipClickCell) {
       // 从pointertap中挪过来的这段逻辑
       const eventArgsSet: SceneEvent = getEventArgsSet(e);
       if (

--- a/packages/vtable/src/event/listener/table-group.ts
+++ b/packages/vtable/src/event/listener/table-group.ts
@@ -620,8 +620,8 @@ export function bindTableGroupListener(eventManager: EventManager) {
     const endedResizeCol = stateManager.isResizeCol();
     const endedResizeRow = stateManager.isResizeRow();
     const endedMoveCol = stateManager.isMoveCol();
-    const endedDragSelect = stateManager.isSelecting() && table.eventManager.isDraging;
-    const shouldSkipClickCell = endedResizeCol || endedResizeRow || endedMoveCol || endedDragSelect;
+    // const endedDragSelect = stateManager.isSelecting() && table.eventManager.isDraging;
+    const shouldSkipClickCell = endedResizeCol || endedResizeRow;
     if (stateManager.interactionState === 'grabing') {
       // stateManager.interactionState = 'default';
       stateManager.updateInteractionState(InteractionState.default);


### PR DESCRIPTION
## Summary
- skip `CLICK_CELL` dispatch when `pointerup` is ending a resize, move, or drag-select interaction
- keep the fix at `table-group.ts` event source instead of editor cache fallback logic
- add a patch change file for `@visactor/vtable`

## Testing
- pnpm --dir packages/vtable compile
- git push -u origin fix/issue-5186-edit-after-resize

Fixes #5186