### PR TITLE
fix: preserve custom layout falsy values

### DIFF
--- a/common/changes/@visactor/vtable/fix-issue-1949-custom-layout-value_2026-06-24-08-02.json
+++ b/common/changes/@visactor/vtable/fix-issue-1949-custom-layout-value_2026-06-24-08-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix: preserve custom layout falsy values",
+      "type": "none",
+      "packageName": "@visactor/vtable"
+    }
+  ],
+  "packageName": "@visactor/vtable",
+  "email": "biukam.w@gmail.com"
+}

--- a/packages/react-vtable/src/table-components/custom/custom-layout.tsx
+++ b/packages/react-vtable/src/table-components/custom/custom-layout.tsx
@@ -138,7 +138,7 @@ export const CustomLayout: React.FC<CustomLayoutProps> = (props: PropsWithChildr
           col,
           row,
           dataValue: table.getCellOriginValue(col, row),
-          value: table.getCellValue(col, row) || '',
+          value: table.getCellValue(col, row),
           rect: {
             left: 0,
             top: 0,

--- a/packages/vtable/__tests__/columns/listTable-custom-layout.test.ts
+++ b/packages/vtable/__tests__/columns/listTable-custom-layout.test.ts
@@ -320,4 +320,49 @@ describe('listTable-custom-layout init test', () => {
     expect(rectBound.bottom).toBe(240);
     listTable.release();
   });
+
+  test('custom layout args should preserve falsy cell values', () => {
+    const falsyValueContainer = createDiv();
+    falsyValueContainer.style.position = 'relative';
+    falsyValueContainer.style.width = '400px';
+    falsyValueContainer.style.height = '300px';
+
+    const receivedArgs = [];
+    const createCustomLayout = () => args => {
+      receivedArgs.push(args);
+
+      return {
+        rootContainer: new VTable.CustomLayout.Container({
+          width: args.rect.width,
+          height: args.rect.height
+        }),
+        renderDefault: false
+      };
+    };
+
+    const falsyValueTable = new ListTable(falsyValueContainer, {
+      columns: [
+        {
+          field: 'zero',
+          title: 'zero',
+          customLayout: createCustomLayout()
+        },
+        {
+          field: 'enabled',
+          title: 'enabled',
+          customLayout: createCustomLayout()
+        }
+      ],
+      records: [
+        {
+          zero: 0,
+          enabled: false
+        }
+      ]
+    });
+
+    expect(receivedArgs.map(args => args.value)).toEqual([0, false]);
+    expect(receivedArgs.map(args => args.dataValue)).toEqual([0, false]);
+    falsyValueTable.release();
+  });
 });

--- a/packages/vtable/src/scenegraph/component/custom.ts
+++ b/packages/vtable/src/scenegraph/component/custom.ts
@@ -57,7 +57,7 @@ export function dealWithCustom(
       col: range?.start.col ?? col,
       row: range?.start.row ?? row,
       dataValue: table.getCellOriginValue(col, row),
-      value: table.getCellValue(col, row) || '',
+      value: table.getCellValue(col, row),
       rect: {
         left: 0,
         top: 0,
@@ -96,7 +96,7 @@ export function dealWithCustom(
       col,
       row,
       dataValue: table.getCellOriginValue(col, row),
-      value: table.getCellValue(col, row) || '',
+      value: table.getCellValue(col, row),
       rect: {
         left: 0,
         top: 0,

--- a/packages/vtable/src/scenegraph/layout/compute-col-width.ts
+++ b/packages/vtable/src/scenegraph/layout/compute-col-width.ts
@@ -440,7 +440,7 @@ function computeCustomRenderWidth(col: number, row: number, table: BaseTableAPI)
       col: cellRange?.start.col ?? col,
       row: cellRange?.start.row ?? row,
       dataValue: table.getCellOriginValue(col, row),
-      value: table.getCellValue(col, row) || '',
+      value: table.getCellValue(col, row),
       rect: getCellRect(col, row, table),
       table,
       originCol: col,

--- a/packages/vtable/src/scenegraph/layout/compute-row-height.ts
+++ b/packages/vtable/src/scenegraph/layout/compute-row-height.ts
@@ -618,7 +618,7 @@ function computeCustomRenderHeight(col: number, row: number, table: BaseTableAPI
       col: cellRange?.start.col ?? col,
       row: cellRange?.start.row ?? row,
       dataValue: table.getCellOriginValue(col, row),
-      value: table.getCellValue(col, row) || '',
+      value: table.getCellValue(col, row),
       rect: getCellRect(col, row, table),
       table,
       originCol: col,


### PR DESCRIPTION
### This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### Related issue link

close #1949

### Background and solution

Custom layout and custom render callbacks used `table.getCellValue(...) || ''` for the callback `value`. That converted valid falsy cell values such as `0` and `false` into an empty string, so custom layout logic could not distinguish those values from an empty cell.

This change passes `table.getCellValue(...)` through directly for custom layout and custom render callback args, the custom width/height measurement paths, and React custom layout updates.

### Changelog

| Language | Changelog |
| --- | --- |
| English | Preserve falsy cell values for custom layout and custom render callbacks. |
| Chinese | 自定义布局和自定义渲染回调中保留单元格的假值。 |

### Self-Check before Merge

Please check all items below before requesting a reviewing.

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

### Summary

- Preserve `0` and `false` cell values in custom layout and custom render callback args.
- Apply the same value passthrough during custom width/height computation and React custom layout updates.
- Add a regression test for custom layout callback args.

### Walkthrough

- Added a custom layout test covering `0` and `false` callback values.
- Removed the empty-string fallback from custom layout and custom render value plumbing.

### Validation

- `node ../../common/scripts/install-run-rushx.js test -- columns/listTable-custom-layout.test.ts --runInBand`
- `node common/scripts/install-run-rush.js build -t @visactor/react-vtable`
- `node common/scripts/install-run-rush.js build -t @visactor/vtable-sheet`
- `git push -u origin fix/issue-1949-custom-layout-value`
