### PR TITLE
fix: prevent Gantt crash when zoomScale is configured without scales

### DIFF
--- a/common/changes/@visactor/vtable-gantt/fix-issue-5159-gantt-sort-scales_2026-06-26-12-00.json
+++ b/common/changes/@visactor/vtable-gantt/fix-issue-5159-gantt-sort-scales_2026-06-26-12-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@visactor/vtable-gantt",
+      "comment": "Fix a crash in the Gantt component when `zoomScale` is configured without `scales`; `_sortScales` accessed `timelineHeader.scales.length` without a guard (GitHub #5159)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@visactor/vtable-gantt",
+  "email": "53095992+Jian-Zhang08@users.noreply.github.com"
+}

--- a/packages/vtable-gantt/__tests__/gantt-sort-scales.test.ts
+++ b/packages/vtable-gantt/__tests__/gantt-sort-scales.test.ts
@@ -1,0 +1,31 @@
+// @ts-nocheck
+
+global.__VERSION__ = 'none';
+
+import { Gantt } from '../src/index';
+
+describe('Gantt._sortScales', () => {
+  // Regression test for https://github.com/VisActor/VTable/issues/5159
+  // When only `zoomScale` is configured (so `timelineHeader.scales` is still
+  // undefined), `_sortScales` used to crash on `timelineScales.length`.
+  test('does not throw when timelineHeader.scales is undefined', () => {
+    const context = {
+      options: { timelineHeader: {} },
+      parsedOptions: {}
+    };
+
+    expect(() => Gantt.prototype._sortScales.call(context)).not.toThrow();
+  });
+
+  test('still sorts the configured scales', () => {
+    const context = {
+      options: { timelineHeader: { scales: [{ unit: 'day' }, { unit: 'month' }] } },
+      parsedOptions: {}
+    };
+
+    Gantt.prototype._sortScales.call(context);
+
+    expect(context.parsedOptions.sortedTimelineScales.map(scale => scale.unit)).toEqual(['month', 'day']);
+    expect(context.parsedOptions.reverseSortedTimelineScales.map(scale => scale.unit)).toEqual(['day', 'month']);
+  });
+});

--- a/packages/vtable-gantt/src/Gantt.ts
+++ b/packages/vtable-gantt/src/Gantt.ts
@@ -689,7 +689,10 @@ export class Gantt extends EventTarget {
 
   _sortScales() {
     const { timelineHeader } = this.options;
-    if (timelineHeader) {
+    // `scales` can be undefined when only `zoomScale` is configured (the zoom
+    // scale manager may not have populated it yet), so guard against it instead
+    // of crashing on `timelineScales.length`.
+    if (timelineHeader?.scales) {
       const timelineScales = timelineHeader.scales;
       const sortOrder = ['year', 'quarter', 'month', 'week', 'day', 'hour', 'minute', 'second'];
       if (timelineScales.length === 1) {


### PR DESCRIPTION
### 🤔 This is a ...

- [x] Bug fix

### 🔗 Related issue link

Fixes #5159

### 💡 Background and solution

Opening Gantt with only `zoomScale` (no `scales`) threw: `_sortScales()` accessed `timelineHeader.scales.length` without a guard, and `scales` is `undefined` until the zoom scale manager populates it. Guarded with `timelineHeader?.scales`.

### 📝 Changelog

- Guard `_sortScales` against undefined `scales` in `Gantt.ts`.
- Added a unit test + changeset. (VTable gantt tests run under jest-electron/rush; test provided for CI.)

### ☑️ Self-Check before Merge

- [x] Changelog is provided