### PR TITLE
fix: render group title for single-column lists

### DIFF
--- a/common/changes/@visactor/vtable/fix-issue-5014-group-single-column_2026-07-06-13-55.json
+++ b/common/changes/@visactor/vtable/fix-issue-5014-group-single-column_2026-07-06-13-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Render group title for single-column list tables.",
+      "type": "none",
+      "packageName": "@visactor/vtable"
+    }
+  ],
+  "packageName": "@visactor/vtable",
+  "email": "biukam.w@gmail.com"
+}

--- a/packages/vtable/__tests__/layout/listTable-group-single-column.test.ts
+++ b/packages/vtable/__tests__/layout/listTable-group-single-column.test.ts
@@ -1,0 +1,49 @@
+// @ts-nocheck
+import { ListTable } from '../../src';
+import { createDiv } from '../dom';
+
+global.__VERSION__ = 'none';
+
+function collectText(graphic: any): string[] {
+  const result: string[] = [];
+  const children = graphic?.children ?? [];
+
+  for (const child of children) {
+    if (child.type === 'text') {
+      result.push(child.attribute?.text);
+    }
+    result.push(...collectText(child));
+  }
+
+  return result;
+}
+
+describe('listTable group single column', () => {
+  test('renders parent group title when there is only one data column', () => {
+    const containerDom: HTMLElement = createDiv();
+    containerDom.style.position = 'relative';
+    containerDom.style.width = '500px';
+    containerDom.style.height = '360px';
+
+    const table = new ListTable(containerDom, {
+      records: [
+        { category: 'Furniture', subCategory: 'Bookcases', value: 'Bookcase' },
+        { category: 'Furniture', subCategory: 'Chairs', value: 'Chair' }
+      ],
+      columns: [{ field: 'value', title: 'Value', width: 180 }],
+      widthMode: 'standard',
+      groupConfig: {
+        groupBy: ['category', 'subCategory'],
+        titleFieldFormat: record => `${record.vtableMergeName}(${record.children.length})`
+      }
+    });
+
+    const groupRecord = table.getCellRawRecord(0, 1);
+    expect(groupRecord.vtableMerge).toBe(true);
+
+    const text = collectText(table.scenegraph.getCell(0, 1, true));
+    expect(text).toContain('Furniture(2)');
+
+    table.release();
+  });
+});

--- a/packages/vtable/src/scenegraph/group-creater/cell-helper.ts
+++ b/packages/vtable/src/scenegraph/group-creater/cell-helper.ts
@@ -666,12 +666,12 @@ export function updateCell(
     isMerge = range.start.col !== range.end.col || range.start.row !== range.end.row;
   }
   let isVtableMerge = false;
-  if (table.internalProps.enableTreeNodeMerge && isMerge) {
+  if (table.internalProps.enableTreeNodeMerge && range) {
     const rawRecord = table.getCellRawRecord(range.start.col, range.start.row);
     const { vtableMergeName, vtableMerge } = rawRecord ?? {};
 
-    isVtableMerge = vtableMerge;
-    if (vtableMerge) {
+    isVtableMerge = vtableMerge && (isMerge || !table.isSeriesNumberInBody(col, row));
+    if (isVtableMerge) {
       mayHaveIcon = true;
       if ((table.internalProps as ListTableProtected).groupTitleCustomLayout) {
         customResult = dealWithCustom(
@@ -712,6 +712,7 @@ export function updateCell(
   if (
     !addNew &&
     !isMerge &&
+    !isVtableMerge &&
     !(define?.customLayout || define?.customRender || define?.headerCustomLayout || define?.headerCustomRender) &&
     (forceFastUpdate || canUseFastUpdate(col, row, oldCellGroup, autoWrapText, mayHaveIcon, table))
   ) {

--- a/packages/vtable/src/scenegraph/group-creater/column-helper.ts
+++ b/packages/vtable/src/scenegraph/group-creater/column-helper.ts
@@ -169,12 +169,12 @@ export function createComplexColumn(
       }
     }
     let isVtableMerge = false;
-    if (table.internalProps.enableTreeNodeMerge && isMerge) {
+    if (table.internalProps.enableTreeNodeMerge && range) {
       const rawRecord = table.getCellRawRecord(range.start.col, range.start.row);
       const { vtableMergeName, vtableMerge } = rawRecord ?? {};
 
-      isVtableMerge = vtableMerge;
-      if (vtableMerge) {
+      isVtableMerge = vtableMerge && (isMerge || !table.isSeriesNumberInBody(col, row));
+      if (isVtableMerge) {
         mayHaveIcon = true;
         if ((table.internalProps as ListTableProtected).groupTitleCustomLayout) {
           customResult = dealWithCustom(


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/VTable/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link

fix #5014

### 💡 Background and solution

When `ListTable` uses `groupConfig` with only one data column, parent group rows still carry `vtableMerge` group-title data, but their merge range collapses to a single cell. The renderer previously entered the group-title rendering path only when the range spanned multiple cells, so the parent group row could render blank.

This change treats `vtableMerge` rows as group-title cells even when the merge range is a single data cell, while still excluding row series cells. It also avoids the normal fast text update path for those group-title cells so `groupTitleFieldFormat` is applied.

A regression test was added for a grouped `ListTable` with one data column to verify the parent group title is rendered.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Render group title rows correctly for grouped ListTable with only one data column. |
| 🇨🇳 Chinese | 修复 ListTable 分组表在仅有一个数据列时父分组标题行空白的问题。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough