### PR TITLE
fix: handle null table container

### DIFF
--- a/common/changes/@visactor/vtable/fix-issue-5217-null-container_2026-07-13-13-10.json
+++ b/common/changes/@visactor/vtable/fix-issue-5217-null-container_2026-07-13-13-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix: handle null table container",
+      "type": "none",
+      "packageName": "@visactor/vtable"
+    }
+  ],
+  "packageName": "@visactor/vtable",
+  "email": "biukam.w@gmail.com"
+}

--- a/packages/vtable/__tests__/options/listTable-null-container.test.ts
+++ b/packages/vtable/__tests__/options/listTable-null-container.test.ts
@@ -1,0 +1,10 @@
+// @ts-nocheck
+import { ListTable } from '../../src';
+
+global.__VERSION__ = 'none';
+
+describe('ListTable null container', () => {
+  test('throws a clear error when the container argument is null', () => {
+    expect(() => new ListTable(null, { columns: [] })).toThrow("vtable's container is undefined");
+  });
+});

--- a/packages/vtable/src/core/BaseTable.ts
+++ b/packages/vtable/src/core/BaseTable.ts
@@ -267,7 +267,7 @@ export abstract class BaseTable extends EventTarget implements BaseTableAPI {
     if (Env.mode === 'node') {
       options = container as BaseTableConstructorOptions;
       container = null;
-    } else if (!(container instanceof HTMLElement)) {
+    } else if (container && !(container instanceof HTMLElement)) {
       options = container as BaseTableConstructorOptions;
       if ((container as BaseTableConstructorOptions).container) {
         container = (container as BaseTableConstructorOptions).container;


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/VisActor/VTable/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link

fix #5217

### 💡 Background and solution

When `ListTable` is constructed with a null container, `BaseTable` treats the first argument as constructor options and reads `container.container` before the existing validation runs. This causes an unhandled null-reference error instead of the intended container validation error.

This change only treats a truthy non-`HTMLElement` first argument as the options overload. An explicit null container now reaches the existing validation and throws `vtable's container is undefined`.

A regression test covers the null-container constructor path.

Validation:

- `node common/scripts/install-run-rush.js run -p @visactor/vtable -s compile`
- `node common/scripts/install-run-rush.js test --only tag:package`

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Throw a clear validation error when ListTable receives a null container. |
| 🇨🇳 Chinese | ListTable 接收到 null 容器时抛出明确的校验错误，避免空引用异常。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough