### PR TITLE
Fix/pr 5202 gantt zoomscale review

### DIFF
--- a/common/changes/@visactor/vtable-gantt/fix-issue-5159-gantt-sort-scales_2026-06-26-12-00.json
+++ b/common/changes/@visactor/vtable-gantt/fix-issue-5159-gantt-sort-scales_2026-06-26-12-00.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@visactor/vtable-gantt",
-      "comment": "Fix a crash in the Gantt component when `zoomScale` is configured without `scales`; `_sortScales` accessed `timelineHeader.scales.length` without a guard (GitHub #5159)",
+      "comment": "Fix a crash in the Gantt component when `zoomScale` is configured without `timelineHeader.scales`, and initialize timeline scales from the active zoom level or a safe default (GitHub #5159)",
       "type": "patch"
     }
   ],

--- a/common/changes/@visactor/vtable-gantt/fix-issue-5159-gantt-sort-scales_2026-06-26-12-00.json
+++ b/common/changes/@visactor/vtable-gantt/fix-issue-5159-gantt-sort-scales_2026-06-26-12-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@visactor/vtable-gantt",
+      "comment": "Fix a crash in the Gantt component when `zoomScale` is configured without `scales`; `_sortScales` accessed `timelineHeader.scales.length` without a guard (GitHub #5159)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@visactor/vtable-gantt",
+  "email": "53095992+Jian-Zhang08@users.noreply.github.com"
+}

--- a/packages/vtable-gantt/__tests__/gantt-sort-scales.test.ts
+++ b/packages/vtable-gantt/__tests__/gantt-sort-scales.test.ts
@@ -1,0 +1,31 @@
+// @ts-nocheck
+
+global.__VERSION__ = 'none';
+
+import { Gantt } from '../src/index';
+
+describe('Gantt._sortScales', () => {
+  // Regression test for https://github.com/VisActor/VTable/issues/5159
+  // When only `zoomScale` is configured (so `timelineHeader.scales` is still
+  // undefined), `_sortScales` used to crash on `timelineScales.length`.
+  test('does not throw when timelineHeader.scales is undefined', () => {
+    const context = {
+      options: { timelineHeader: {} },
+      parsedOptions: {}
+    };
+
+    expect(() => Gantt.prototype._sortScales.call(context)).not.toThrow();
+  });
+
+  test('still sorts the configured scales', () => {
+    const context = {
+      options: { timelineHeader: { scales: [{ unit: 'day' }, { unit: 'month' }] } },
+      parsedOptions: {}
+    };
+
+    Gantt.prototype._sortScales.call(context);
+
+    expect(context.parsedOptions.sortedTimelineScales.map(scale => scale.unit)).toEqual(['month', 'day']);
+    expect(context.parsedOptions.reverseSortedTimelineScales.map(scale => scale.unit)).toEqual(['day', 'month']);
+  });
+});

--- a/packages/vtable-gantt/__tests__/gantt-sort-scales.test.ts
+++ b/packages/vtable-gantt/__tests__/gantt-sort-scales.test.ts
@@ -19,6 +19,23 @@ describe('Gantt._sortScales', () => {
     expect(context.parsedOptions.reverseSortedTimelineScales.map(scale => scale.unit)).toEqual(['day']);
   });
 
+  test('does not share mutable default scale objects across calls', () => {
+    const firstContext = {
+      options: {},
+      parsedOptions: {}
+    };
+    const secondContext = {
+      options: {},
+      parsedOptions: {}
+    };
+
+    Gantt.prototype._sortScales.call(firstContext);
+    firstContext.parsedOptions.sortedTimelineScales[0].timelineDates = ['stale'];
+    Gantt.prototype._sortScales.call(secondContext);
+
+    expect(secondContext.parsedOptions.sortedTimelineScales[0].timelineDates).toBeUndefined();
+  });
+
   test('still sorts the configured scales', () => {
     const context = {
       options: { timelineHeader: { scales: [{ unit: 'day' }, { unit: 'month' }] } },

--- a/packages/vtable-gantt/__tests__/gantt-sort-scales.test.ts
+++ b/packages/vtable-gantt/__tests__/gantt-sort-scales.test.ts
@@ -15,6 +15,8 @@ describe('Gantt._sortScales', () => {
     };
 
     expect(() => Gantt.prototype._sortScales.call(context)).not.toThrow();
+    expect(context.parsedOptions.sortedTimelineScales.map(scale => scale.unit)).toEqual(['day']);
+    expect(context.parsedOptions.reverseSortedTimelineScales.map(scale => scale.unit)).toEqual(['day']);
   });
 
   test('still sorts the configured scales', () => {
@@ -25,6 +27,42 @@ describe('Gantt._sortScales', () => {
 
     Gantt.prototype._sortScales.call(context);
 
+    expect(context.parsedOptions.sortedTimelineScales.map(scale => scale.unit)).toEqual(['month', 'day']);
+    expect(context.parsedOptions.reverseSortedTimelineScales.map(scale => scale.unit)).toEqual(['day', 'month']);
+  });
+
+  test('uses zoomScale current level when timelineHeader.scales is undefined', () => {
+    const context = {
+      options: {
+        timelineHeader: {
+          zoomScale: {
+            enabled: true,
+            levels: [
+              [
+                { unit: 'month', step: 1 },
+                { unit: 'day', step: 1 }
+              ]
+            ]
+          }
+        }
+      },
+      zoomScaleManager: {
+        config: {
+          levels: [
+            [
+              { unit: 'month', step: 1 },
+              { unit: 'day', step: 1 }
+            ]
+          ]
+        },
+        getCurrentLevel: () => 0
+      },
+      parsedOptions: {}
+    };
+
+    Gantt.prototype._sortScales.call(context);
+
+    expect(context.options.timelineHeader.scales.map(scale => scale.unit)).toEqual(['month', 'day']);
     expect(context.parsedOptions.sortedTimelineScales.map(scale => scale.unit)).toEqual(['month', 'day']);
     expect(context.parsedOptions.reverseSortedTimelineScales.map(scale => scale.unit)).toEqual(['day', 'month']);
   });

--- a/packages/vtable-gantt/src/Gantt.ts
+++ b/packages/vtable-gantt/src/Gantt.ts
@@ -689,7 +689,10 @@ export class Gantt extends EventTarget {
 
   _sortScales() {
     const { timelineHeader } = this.options;
-    if (timelineHeader) {
+    // `scales` can be undefined when only `zoomScale` is configured (the zoom
+    // scale manager may not have populated it yet), so guard against it instead
+    // of crashing on `timelineScales.length`.
+    if (timelineHeader?.scales) {
       const timelineScales = timelineHeader.scales;
       const sortOrder = ['year', 'quarter', 'month', 'week', 'day', 'hour', 'minute', 'second'];
       if (timelineScales.length === 1) {

--- a/packages/vtable-gantt/src/Gantt.ts
+++ b/packages/vtable-gantt/src/Gantt.ts
@@ -84,6 +84,9 @@ export function createRootElement(padding: any, className: string = 'vtable-gant
 
   return element;
 }
+
+const DEFAULT_TIMELINE_SCALE: ITimelineScale = { unit: 'day', step: 1 };
+
 export class Gantt extends EventTarget {
   options: GanttConstructorOptions;
   container: HTMLElement;
@@ -689,48 +692,55 @@ export class Gantt extends EventTarget {
 
   _sortScales() {
     const { timelineHeader } = this.options;
-    // `scales` can be undefined when only `zoomScale` is configured (the zoom
-    // scale manager may not have populated it yet), so guard against it instead
-    // of crashing on `timelineScales.length`.
-    if (timelineHeader?.scales) {
-      const timelineScales = timelineHeader.scales;
-      const sortOrder = ['year', 'quarter', 'month', 'week', 'day', 'hour', 'minute', 'second'];
-      if (timelineScales.length === 1) {
-        if (
-          timelineScales[0].unit === 'hour' ||
-          timelineScales[0].unit === 'minute' ||
-          timelineScales[0].unit === 'second'
-        ) {
-          this.parsedOptions.timeScaleIncludeHour = true;
-        }
-      }
-      const orderedScales = timelineScales.slice().sort((a, b) => {
-        if (a.unit === 'hour' || a.unit === 'minute' || a.unit === 'second') {
-          this.parsedOptions.timeScaleIncludeHour = true;
-        }
-        const indexA = sortOrder.indexOf(a.unit);
-        const indexB = sortOrder.indexOf(b.unit);
-        if (indexA === -1) {
-          return 1;
-        } else if (indexB === -1) {
-          return -1;
-        }
-        return indexA - indexB;
-      });
-      const reverseOrderedScales = timelineScales.slice().sort((a, b) => {
-        const indexA = sortOrder.indexOf(a.unit);
-        const indexB = sortOrder.indexOf(b.unit);
-        if (indexA === -1) {
-          return 1;
-        } else if (indexB === -1) {
-          return -1;
-        }
-        return indexB - indexA;
-      });
+    const zoomLevelScales = this.zoomScaleManager?.config.levels[this.zoomScaleManager.getCurrentLevel()];
+    const timelineScales =
+      timelineHeader?.scales?.length > 0
+        ? timelineHeader.scales
+        : zoomLevelScales?.length > 0
+        ? zoomLevelScales
+        : [DEFAULT_TIMELINE_SCALE];
 
-      this.parsedOptions.sortedTimelineScales = orderedScales;
-      this.parsedOptions.reverseSortedTimelineScales = reverseOrderedScales;
+    if (timelineHeader && (!timelineHeader.scales || timelineHeader.scales.length === 0)) {
+      timelineHeader.scales = timelineScales.map(scale => ({ ...scale }));
     }
+
+    const sortOrder = ['year', 'quarter', 'month', 'week', 'day', 'hour', 'minute', 'second'];
+    this.parsedOptions.timeScaleIncludeHour = false;
+    if (timelineScales.length === 1) {
+      if (
+        timelineScales[0].unit === 'hour' ||
+        timelineScales[0].unit === 'minute' ||
+        timelineScales[0].unit === 'second'
+      ) {
+        this.parsedOptions.timeScaleIncludeHour = true;
+      }
+    }
+    const orderedScales = timelineScales.slice().sort((a, b) => {
+      if (a.unit === 'hour' || a.unit === 'minute' || a.unit === 'second') {
+        this.parsedOptions.timeScaleIncludeHour = true;
+      }
+      const indexA = sortOrder.indexOf(a.unit);
+      const indexB = sortOrder.indexOf(b.unit);
+      if (indexA === -1) {
+        return 1;
+      } else if (indexB === -1) {
+        return -1;
+      }
+      return indexA - indexB;
+    });
+    const reverseOrderedScales = timelineScales.slice().sort((a, b) => {
+      const indexA = sortOrder.indexOf(a.unit);
+      const indexB = sortOrder.indexOf(b.unit);
+      if (indexA === -1) {
+        return 1;
+      } else if (indexB === -1) {
+        return -1;
+      }
+      return indexB - indexA;
+    });
+
+    this.parsedOptions.sortedTimelineScales = orderedScales;
+    this.parsedOptions.reverseSortedTimelineScales = reverseOrderedScales;
   }
 
   _generateTimeLineDateMap() {

--- a/packages/vtable-gantt/src/Gantt.ts
+++ b/packages/vtable-gantt/src/Gantt.ts
@@ -693,12 +693,15 @@ export class Gantt extends EventTarget {
   _sortScales() {
     const { timelineHeader } = this.options;
     const zoomLevelScales = this.zoomScaleManager?.config.levels[this.zoomScaleManager.getCurrentLevel()];
-    const timelineScales =
-      timelineHeader?.scales?.length > 0
-        ? timelineHeader.scales
-        : zoomLevelScales?.length > 0
-        ? zoomLevelScales
-        : [DEFAULT_TIMELINE_SCALE];
+    const defaultTimelineScale: ITimelineScale = { ...DEFAULT_TIMELINE_SCALE };
+    let timelineScales: ITimelineScale[];
+    if (timelineHeader?.scales?.length > 0) {
+      timelineScales = timelineHeader.scales;
+    } else if (zoomLevelScales?.length > 0) {
+      timelineScales = zoomLevelScales;
+    } else {
+      timelineScales = [defaultTimelineScale];
+    }
 
     if (timelineHeader && (!timelineHeader.scales || timelineHeader.scales.length === 0)) {
       timelineHeader.scales = timelineScales.map(scale => ({ ...scale }));


### PR DESCRIPTION
### 🤔 This is a ...

- [x] Bug fix
- [x] Test Case
- [x] Changelog

### 🔗 Related issue link

fix #5159

### 💡 Background and solution

When Gantt is configured with timelineHeader.zoomScale but without timelineHeader.scales, _sortScales could access missing scales and crash during initialization. The fix now initializes timeline scales from the configured scales, the active zoomScale level, or a safe default day scale.

This PR also avoids sharing the mutable default scale object across calls, preventing generated timelineDates from leaking between Gantt instances.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Gantt initialization when zoomScale is configured without timelineHeader.scales, using the active zoom level or a safe default timeline scale. |
| 🇨🇳 Chinese | 修复 Gantt 配置 zoomScale 但未配置 timelineHeader.scales 时的初始化异常，并使用当前缩放层级或安全默认时间刻度完成初始化。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
