### PR TITLE
fix: export table event type from gantt package

### DIFF
--- a/common/changes/@visactor/vtable-gantt/fix-issue-4320-list-table-event-type_2026-06-25-15-59.json
+++ b/common/changes/@visactor/vtable-gantt/fix-issue-4320-list-table-event-type_2026-06-25-15-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix: export table event type from gantt package",
+      "type": "patch",
+      "packageName": "@visactor/vtable-gantt"
+    }
+  ],
+  "packageName": "@visactor/vtable-gantt",
+  "email": "biukam.w@gmail.com"
+}

--- a/packages/vtable-gantt/__tests__/listTable-event-type.test.ts
+++ b/packages/vtable-gantt/__tests__/listTable-event-type.test.ts
@@ -1,0 +1,12 @@
+// @ts-nocheck
+
+global.__VERSION__ = 'none';
+
+import { TABLE_EVENT_TYPE, VTable } from '../src';
+
+describe('gantt list table event type export', () => {
+  test('exports ListTable event types from package entry', () => {
+    expect(TABLE_EVENT_TYPE).toBe(VTable.TABLE_EVENT_TYPE);
+    expect(TABLE_EVENT_TYPE.CLICK_CELL).toBe('click_cell');
+  });
+});

--- a/packages/vtable-gantt/src/index.ts
+++ b/packages/vtable-gantt/src/index.ts
@@ -13,6 +13,7 @@ import type {
   TextAlignType,
   TextBaselineType
 } from '@visactor/vtable';
+import { TABLE_EVENT_TYPE } from '@visactor/vtable';
 import { Gantt } from './Gantt';
 import * as tools from './tools';
 import * as VRender from './vrender';
@@ -37,6 +38,7 @@ export {
   GroupColumnDefine,
   TextAlignType,
   TextBaselineType,
+  TABLE_EVENT_TYPE,
   tools,
   VRender,
   VTable,


### PR DESCRIPTION
Synced from original PR #5201 on top of latest develop. Original PR: https://github.com/VisActor/VTable/pull/5201