### PR TITLE
fix: hide row series number in aggregation rows

### DIFF
--- a/common/changes/@visactor/vtable/fix-issue-5213-aggregation-series-number_2026-07-14-20-50.json
+++ b/common/changes/@visactor/vtable/fix-issue-5213-aggregation-series-number_2026-07-14-20-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix: hide row series number in aggregation rows",
+      "type": "none",
+      "packageName": "@visactor/vtable"
+    }
+  ],
+  "packageName": "@visactor/vtable",
+  "email": "biukam.w@gmail.com"
+}

--- a/packages/vtable/__tests__/options/listTable-row-series-number-aggregation.test.ts
+++ b/packages/vtable/__tests__/options/listTable-row-series-number-aggregation.test.ts
@@ -1,0 +1,39 @@
+// @ts-nocheck
+import { ListTable, TYPES } from '../../src';
+import { createDiv } from '../dom';
+
+global.__VERSION__ = 'none';
+
+describe('ListTable row series number with aggregation', () => {
+  const container = createDiv();
+  container.style.width = '600px';
+  container.style.height = '400px';
+
+  const table = new ListTable(container, {
+    records: [{ value: 1 }, { value: 2 }],
+    columns: [
+      {
+        field: 'value',
+        title: 'Value',
+        aggregation: {
+          aggregationType: TYPES.AggregationType.SUM
+        }
+      }
+    ],
+    rowSeriesNumber: {
+      title: 'No.'
+    }
+  });
+
+  afterAll(() => {
+    table.release();
+  });
+
+  test('does not display a series number in the aggregation row', () => {
+    const aggregationRow = table.rowCount - 1;
+
+    expect(table.internalProps.layoutMap.isAggregation(0, aggregationRow)).toBe(true);
+    expect(table.getCellValue(0, aggregationRow)).toBe('');
+    expect(table.getCellOriginValue(0, aggregationRow)).toBe('');
+  });
+});

--- a/packages/vtable/src/ListTable.ts
+++ b/packages/vtable/src/ListTable.ts
@@ -579,6 +579,9 @@ export class ListTable extends BaseTable implements ListTableAPI {
         const { title } = table.internalProps.layoutMap.getSeriesNumberHeader(col, row);
         return title;
       }
+      if (table.internalProps.layoutMap.isAggregation(col, row)) {
+        return '';
+      }
       let value;
       if ((this.internalProps as ListTableProtected).groupBy) {
         const record = table.getCellRawRecord(col, row);
@@ -628,6 +631,9 @@ export class ListTable extends BaseTable implements ListTableAPI {
       if (table.internalProps.layoutMap.isSeriesNumberInHeader(col, row)) {
         const { title } = table.internalProps.layoutMap.getSeriesNumberHeader(col, row);
         return title;
+      }
+      if (table.internalProps.layoutMap.isAggregation(col, row)) {
+        return '';
       }
       const { format } = table.internalProps.layoutMap.getSeriesNumberBody(col, row);
       return typeof format === 'function' ? format(col, row, this) : row - this.columnHeaderLevelCount;


### PR DESCRIPTION
<!-- First of all, thank you for your contribution! 😄 For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the main branch. Before submitting your pull request, please make sure the checklist below is confirmed. Your pull requests will be merged after one of the collaborators approve. Thank you! -->

[[中文版模板 / Chinese template](https://github.com/VisActor/VTable/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link

Fixes #5213

### 💡 Background and solution

When `rowSeriesNumber` is used with column aggregation, the series-number value path runs before the aggregation value path. As a result, the aggregation row is treated like a regular data row and displays a row number.

This change returns an empty value for series-number cells that belong to aggregation rows, for both formatted and original cell values. A regression test covers the default bottom aggregation row.

Validation:

- TypeScript compilation
- VTable test suite: 53 suites, 224 tests
- Package pre-push suite, including VTable Sheet, plugins, Gantt, and Vue packages

### 📝 Changelog

| Language | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Hide row series numbers in ListTable aggregation rows. |
| 🇨🇳 Chinese | 修复 ListTable 聚合行错误显示行序号的问题。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough