### PR TITLE
fix: delete reverse-selected rows correctly

### DIFF
--- a/common/changes/@visactor/vtable/fix-issue-5214-delete-selected-rows_2026-07-14-21-21.json
+++ b/common/changes/@visactor/vtable/fix-issue-5214-delete-selected-rows_2026-07-14-21-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix: delete reverse-selected rows from context menu",
+      "type": "none",
+      "packageName": "@visactor/vtable"
+    }
+  ],
+  "packageName": "@visactor/vtable",
+  "email": "biukam.w@gmail.com"
+}

--- a/packages/vtable-plugins/__tests__/context-menu/handle-menu-helper.test.ts
+++ b/packages/vtable-plugins/__tests__/context-menu/handle-menu-helper.test.ts
@@ -1,0 +1,65 @@
+// @ts-nocheck
+import { ListTable } from '@visactor/vtable';
+import { createDiv } from '../../../vtable/__tests__/dom';
+import { MenuHandler } from '../../src/contextmenu/handle-menu-helper';
+import { TableSeriesNumber } from '../../src/table-series-number';
+
+global.__VERSION__ = 'none';
+
+describe('Context menu row deletion', () => {
+  let table: ListTable;
+
+  afterEach(() => {
+    table?.release();
+    document.body.innerHTML = '';
+  });
+
+  test('deletes all rows in a reverse-dragged row selection', () => {
+    const container = createDiv();
+    container.style.width = '600px';
+    container.style.height = '400px';
+
+    const seriesNumberPlugin = new TableSeriesNumber({
+      rowCount: 5,
+      colCount: 2
+    });
+    table = new ListTable({
+      container,
+      showHeader: false,
+      columns: [
+        { field: 'id', title: 'ID' },
+        { field: 'name', title: 'Name' }
+      ],
+      records: [
+        { id: 0, name: 'A' },
+        { id: 1, name: 'B' },
+        { id: 2, name: 'C' },
+        { id: 3, name: 'D' },
+        { id: 4, name: 'E' }
+      ],
+      syncRecordOperationsToSourceRecords: true,
+      plugins: [seriesNumberPlugin]
+    });
+
+    table.stateManager.select.ranges = [
+      {
+        start: { col: 0, row: 3 },
+        end: { col: table.colCount - 1, row: 1 }
+      }
+    ];
+
+    const selectCells = jest.spyOn(table, 'selectCells');
+    seriesNumberPlugin['handleSeriesNumberCellRightClick']({
+      detail: {
+        seriesNumberCell: { id: 2, name: 'row-series-number-cell' },
+        event: new MouseEvent('contextmenu')
+      }
+    });
+
+    expect(selectCells).not.toHaveBeenCalled();
+
+    new MenuHandler().handleDeleteRow(table);
+
+    expect(table.records.map(record => record.id)).toEqual([0, 4]);
+  });
+});

--- a/packages/vtable-plugins/src/contextmenu/handle-menu-helper.ts
+++ b/packages/vtable-plugins/src/contextmenu/handle-menu-helper.ts
@@ -105,7 +105,9 @@ export class MenuHandler {
       const deleteRowIndexs: number[] = [];
       for (let i = 0; i < selectRanges.length; i++) {
         const range = selectRanges[i];
-        for (let j = range.start.row; j <= range.end.row; j++) {
+        const startRow = Math.min(range.start.row, range.end.row);
+        const endRow = Math.max(range.start.row, range.end.row);
+        for (let j = startRow; j <= endRow; j++) {
           if (!deleteRowIndexs.includes(j)) {
             deleteRowIndexs.push(j);
           }

--- a/packages/vtable-plugins/src/table-series-number.ts
+++ b/packages/vtable-plugins/src/table-series-number.ts
@@ -289,9 +289,11 @@ export class TableSeriesNumber implements pluginsDefinition.IVTablePlugin {
       const rowIndex = seriesNumberCell.id;
       //判断rowIndex整行是否被选中
       const isRowSelected = this.table.stateManager.select.ranges.some(range => {
+        const startRow = Math.min(range.start.row, range.end.row);
+        const endRow = Math.max(range.start.row, range.end.row);
         return (
-          range.start.row <= rowIndex &&
-          rowIndex <= range.end.row &&
+          startRow <= rowIndex &&
+          rowIndex <= endRow &&
           range.start.col === 0 &&
           range.end.col === this.table.colCount - 1
         );


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link

Fixes #5214

### 💡 Background and solution

VTable Sheet keeps the original drag direction in row selection ranges. When rows are selected from bottom to top, the range has a larger start row than end row.

The context-menu flow previously assumed ascending row ranges in two places:

- Right-clicking inside a reverse-dragged selection was treated as clicking outside it, so the selection could collapse to one row.
- The delete handler iterated directly from the start row to the end row, so a reverse range was not fully deleted.

This change normalizes the row boundaries before checking whether the right-clicked row belongs to the selection and before collecting rows to delete. A regression test covers reverse row selection, right-click preservation, and batch deletion with VTable Sheet's record synchronization mode.

Validation:

- `@visactor/vtable-plugins` TypeScript compilation
- `@visactor/vtable-plugins`: 8 suites, 58 tests
- Pre-push package suite:
  - `@visactor/vtable-sheet`: 76 suites, 442 tests
  - `@visactor/vtable`: 52 suites, 223 tests
  - Related Gantt and Vue package tests

### 📝 Changelog

| Language | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix deleting rows selected by dragging upward in VTable Sheet. |
| 🇨🇳 Chinese | 修复 VTable Sheet 从下向上拖选多行后右键删除不正确的问题。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough