### PR TITLE
fix: preserve blank rows when importing Excel files

### DIFF
--- a/common/changes/@visactor/vtable-plugins/fix-issue-5227-excel-leading-blank-row_2026-07-15-09-34.json
+++ b/common/changes/@visactor/vtable-plugins/fix-issue-5227-excel-leading-blank-row_2026-07-15-09-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix: preserve blank rows when importing excel files (GitHub #5227)",
+      "type": "patch",
+      "packageName": "@visactor/vtable-plugins"
+    }
+  ],
+  "packageName": "@visactor/vtable-plugins",
+  "email": "biukam.w@gmail.com"
+}

--- a/packages/vtable-plugins/__tests__/excel-import/excel.test.ts
+++ b/packages/vtable-plugins/__tests__/excel-import/excel.test.ts
@@ -1,0 +1,22 @@
+import ExcelJS from 'exceljs';
+import { parseWorksheetToSheetData } from '../../src/excel-import/excel';
+
+describe('Excel worksheet import', () => {
+  test('preserves data after a blank first row', async () => {
+    const workbook = new ExcelJS.Workbook();
+    const worksheet = workbook.addWorksheet('Sheet1');
+    worksheet.getCell('A2').value = 'Name';
+    worksheet.getCell('B2').value = 'Age';
+    worksheet.getCell('A3').value = 'Alice';
+    worksheet.getCell('B3').value = 30;
+
+    const result = await parseWorksheetToSheetData(worksheet, 0);
+
+    expect(result.rowCount).toBe(3);
+    expect(result.data).toEqual([
+      [null, null],
+      ['Name', 'Age'],
+      ['Alice', 30]
+    ]);
+  });
+});

--- a/packages/vtable-plugins/src/excel-import/excel.ts
+++ b/packages/vtable-plugins/src/excel-import/excel.ts
@@ -150,9 +150,16 @@ export async function parseWorksheetToSheetData(
   const sheetTitle = worksheet.name || `Sheet${sheetIndex + 1}`;
   const sheetKey = `sheet_${Date.now()}_${sheetIndex}`;
 
-  // 获取实际数据范围
-  const rowCount = worksheet.actualRowCount || 0;
-  const columnCount = worksheet.actualColumnCount || 0;
+  // 获取实际数据范围。actualRowCount/actualColumnCount 只统计非空行列的数量，
+  // 当数据前面或中间存在空白行列时，不能作为最后一个数据单元格的索引。
+  let rowCount = 0;
+  let columnCount = 0;
+  worksheet.eachRow((row, rowNumber) => {
+    rowCount = Math.max(rowCount, rowNumber);
+    row.eachCell((_cell, colNumber) => {
+      columnCount = Math.max(columnCount, colNumber);
+    });
+  });
 
   if (rowCount === 0 || columnCount === 0) {
     // 空 sheet，但仍需要解析合并单元格信息（可能只有合并单元格没有数据）


### PR DESCRIPTION
### 🤔 This is a

- [x] Bug fix

### 🔗 Related issue link

Closes #5227

### 💡 Background and solution

When an Excel worksheet starts with a blank row, ExcelJS reports the number of non-empty rows and columns separately from their last populated coordinates. The importer used those counts as loop bounds, so a valid data row after a blank row was omitted.

This change derives the import bounds from each populated row and cell coordinate, preserving blank rows and columns while retaining all data.

### 📝 Changelog

| Language | Changelog |
| --- | --- |
| 🇺🇸 English | Fixed Excel imports that dropped data when the worksheet began with a blank row. |
| 🇨🇳 Chinese | 修复 Excel 首行为空时导入结果缺失数据的问题。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### 🧪 Tests

- npm run compile (packages/vtable-plugins)
- ./node_modules/.bin/jest __tests__/excel-import/excel.test.ts --runInBand --coverage=false
