### PR TITLE
fix: hide row series number in aggregation rows with demo

### DIFF
--- a/common/changes/@visactor/vtable/fix-issue-5213-aggregation-series-number_2026-07-14-20-50.json
+++ b/common/changes/@visactor/vtable/fix-issue-5213-aggregation-series-number_2026-07-14-20-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix: hide row series number in aggregation rows",
+      "type": "none",
+      "packageName": "@visactor/vtable"
+    }
+  ],
+  "packageName": "@visactor/vtable",
+  "email": "biukam.w@gmail.com"
+}

--- a/packages/vtable/__tests__/options/listTable-row-series-number-aggregation.test.ts
+++ b/packages/vtable/__tests__/options/listTable-row-series-number-aggregation.test.ts
@@ -1,0 +1,39 @@
+// @ts-nocheck
+import { ListTable, TYPES } from '../../src';
+import { createDiv } from '../dom';
+
+global.__VERSION__ = 'none';
+
+describe('ListTable row series number with aggregation', () => {
+  const container = createDiv();
+  container.style.width = '600px';
+  container.style.height = '400px';
+
+  const table = new ListTable(container, {
+    records: [{ value: 1 }, { value: 2 }],
+    columns: [
+      {
+        field: 'value',
+        title: 'Value',
+        aggregation: {
+          aggregationType: TYPES.AggregationType.SUM
+        }
+      }
+    ],
+    rowSeriesNumber: {
+      title: 'No.'
+    }
+  });
+
+  afterAll(() => {
+    table.release();
+  });
+
+  test('does not display a series number in the aggregation row', () => {
+    const aggregationRow = table.rowCount - 1;
+
+    expect(table.internalProps.layoutMap.isAggregation(0, aggregationRow)).toBe(true);
+    expect(table.getCellValue(0, aggregationRow)).toBe('');
+    expect(table.getCellOriginValue(0, aggregationRow)).toBe('');
+  });
+});

--- a/packages/vtable/examples/debug/issue-5213-row-series-number-aggregation.ts
+++ b/packages/vtable/examples/debug/issue-5213-row-series-number-aggregation.ts
@@ -1,0 +1,84 @@
+import * as VTable from '../../src';
+
+const CONTAINER_ID = 'vTable';
+
+const removeDemoToolbar = () => {
+  document.getElementById('issue5213Toolbar')?.remove();
+};
+
+const setStatus = (message: string, pass: boolean) => {
+  const statusNode = document.getElementById('issue5213Status');
+  if (!statusNode) {
+    return;
+  }
+  statusNode.textContent = message;
+  statusNode.style.color = pass ? '#237804' : '#cf1322';
+};
+
+export function createTable() {
+  removeDemoToolbar();
+
+  const container = document.getElementById(CONTAINER_ID)!;
+  container.style.width = '640px';
+  container.style.height = '360px';
+
+  const toolbar = document.createElement('div');
+  toolbar.id = 'issue5213Toolbar';
+  toolbar.style.cssText = [
+    'display: flex',
+    'gap: 8px',
+    'align-items: center',
+    'height: 40px',
+    'font-size: 12px'
+  ].join(';');
+  toolbar.innerHTML = `
+    <button id="issue5213Check">检查聚合行序号</button>
+    <span>预期：聚合行序号列为空；旧逻辑会显示行号。</span>
+    <strong id="issue5213Status"></strong>
+  `;
+  container.before(toolbar);
+
+  const tableInstance = new VTable.ListTable(container, {
+    records: [{ value: 1 }, { value: 2 }],
+    columns: [
+      {
+        field: 'value',
+        title: 'Value',
+        width: 160,
+        aggregation: {
+          aggregationType: VTable.TYPES.AggregationType.SUM
+        }
+      }
+    ],
+    rowSeriesNumber: {
+      title: 'No.'
+    },
+    defaultRowHeight: 36
+  });
+
+  const checkAggregationSeriesNumber = () => {
+    const aggregationRow = tableInstance.rowCount - 1;
+    const displayValue = tableInstance.getCellValue(0, aggregationRow);
+    const originValue = tableInstance.getCellOriginValue(0, aggregationRow);
+    const isAggregation = tableInstance.internalProps.layoutMap.isAggregation(0, aggregationRow);
+    const pass = isAggregation && displayValue === '' && originValue === '';
+
+    setStatus(
+      `${pass ? 'PASS' : 'FAIL'} | aggregationRow=${aggregationRow}, display=${String(displayValue)}, origin=${String(
+        originValue
+      )}`,
+      pass
+    );
+  };
+
+  document.getElementById('issue5213Check')?.addEventListener('click', checkAggregationSeriesNumber);
+  requestAnimationFrame(checkAggregationSeriesNumber);
+
+  const release = tableInstance.release.bind(tableInstance);
+  tableInstance.release = () => {
+    removeDemoToolbar();
+    release();
+  };
+
+  (window as any).tableInstance = tableInstance;
+}

--- a/packages/vtable/examples/menu.ts
+++ b/packages/vtable/examples/menu.ts
@@ -52,6 +52,10 @@ export const menus = [
       },
       {
         path: 'debug',
+        name: 'issue-5213-row-series-number-aggregation'
+      },
+      {
+        path: 'debug',
         name: 'header-frame-border-null-color'
       }
     ]

--- a/packages/vtable/src/ListTable.ts
+++ b/packages/vtable/src/ListTable.ts
@@ -579,6 +579,9 @@ export class ListTable extends BaseTable implements ListTableAPI {
         const { title } = table.internalProps.layoutMap.getSeriesNumberHeader(col, row);
         return title;
       }
+      if (table.internalProps.layoutMap.isAggregation(col, row)) {
+        return '';
+      }
       let value;
       if ((this.internalProps as ListTableProtected).groupBy) {
         const record = table.getCellRawRecord(col, row);
@@ -628,6 +631,9 @@ export class ListTable extends BaseTable implements ListTableAPI {
       if (table.internalProps.layoutMap.isSeriesNumberInHeader(col, row)) {
         const { title } = table.internalProps.layoutMap.getSeriesNumberHeader(col, row);
         return title;
+      }
+      if (table.internalProps.layoutMap.isAggregation(col, row)) {
+        return '';
       }
       const { format } = table.internalProps.layoutMap.getSeriesNumberBody(col, row);
       return typeof format === 'function' ? format(col, row, this) : row - this.columnHeaderLevelCount;


### PR DESCRIPTION
## Summary
- Includes PR #5224 changes for issue #5213.
- Adds a browser demo to reproduce and verify row series number behavior in aggregation rows.

## Demo
- packages/vtable/examples/debug/issue-5213-row-series-number-aggregation.ts
- Open VTable examples and select issue-5213-row-series-number-aggregation.
- Click "检查聚合行序号"; fixed behavior shows PASS.

## Validation
- Browser interaction verified locally with Chrome DevTools MCP: PASS | aggregationRow=3, display=, origin=
- @visactor/vtable compile passed.