### PR TITLE
fix: prevent page scroll after canceling table rotation

### DIFF
--- a/common/changes/@visactor/vtable-plugins/fix-issue-5235-rotate-wheel_2026-07-25-12-00.json
+++ b/common/changes/@visactor/vtable-plugins/fix-issue-5235-rotate-wheel_2026-07-25-12-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@visactor/vtable-plugins",
+      "comment": "fix: keep wheel events cancelable after restoring a rotated table (GitHub #5235)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@visactor/vtable-plugins",
+  "email": "biukam.w@gmail.com"
+}

--- a/packages/vtable-plugins/__tests__/rotate-table-plugin.test.ts
+++ b/packages/vtable-plugins/__tests__/rotate-table-plugin.test.ts
@@ -1,0 +1,88 @@
+// @ts-nocheck
+jest.mock('@visactor/vtable', () => {
+  const vrender = jest.requireActual('../../vtable/src/vrender');
+
+  return {
+    matrixAllocate: vrender.matrixAllocate,
+    transformPointForCanvas: vrender.transformPointForCanvas,
+    mapToCanvasPointForCanvas: vrender.mapToCanvasPointForCanvas,
+    registerGlobalEventTransformer: vrender.registerGlobalEventTransformer,
+    registerWindowEventTransformer: vrender.registerWindowEventTransformer,
+    vglobal: {
+      mapToCanvasPoint: jest.fn(),
+      setEventListenerTransformer: jest.fn()
+    },
+    TABLE_EVENT_TYPE: {
+      INITIALIZED: 'initialized'
+    }
+  };
+});
+
+import { vglobal } from '@visactor/vtable';
+import { cancelTransform } from '../src/rotate-table';
+
+global.__VERSION__ = 'none';
+
+describe('RotateTablePlugin cancel transform - issue #5235', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('keeps wheel preventDefault connected to the native event after canceling rotation', () => {
+    const tableElement = document.createElement('div');
+    jest.spyOn(tableElement, 'getBoundingClientRect').mockReturnValue({
+      x: 40,
+      y: 80,
+      left: 40,
+      top: 80,
+      right: 640,
+      bottom: 480,
+      width: 600,
+      height: 400,
+      toJSON: () => ({})
+    });
+
+    const originalMapToCanvasPoint = vglobal.mapToCanvasPoint;
+    const windowSetEventListenerTransformer = jest.fn();
+    let globalTransformer;
+
+    jest.spyOn(vglobal, 'setEventListenerTransformer').mockImplementation(transformer => {
+      globalTransformer = transformer;
+    });
+
+    const table = {
+      rotateDegree: 90,
+      getElement: () => tableElement,
+      scenegraph: {
+        stage: {
+          window: {
+            setEventListenerTransformer: windowSetEventListenerTransformer
+          }
+        }
+      },
+      pluginManager: {
+        getPluginByName: () => ({
+          vglobal_mapToCanvasPoint: originalMapToCanvasPoint
+        })
+      }
+    };
+
+    cancelTransform.call(table, document.createElement('div'));
+
+    const nativeWheelEvent = new WheelEvent('wheel', {
+      cancelable: true,
+      clientX: 120,
+      clientY: 160,
+      deltaY: 40
+    });
+    const transformedWheelEvent = globalTransformer(nativeWheelEvent);
+
+    transformedWheelEvent.preventDefault();
+
+    expect(transformedWheelEvent).toBe(nativeWheelEvent);
+    expect(nativeWheelEvent.defaultPrevented).toBe(true);
+    expect(windowSetEventListenerTransformer).toHaveBeenCalledTimes(1);
+    expect(table.rotateDegree).toBe(0);
+    expect(vglobal.mapToCanvasPoint).toBe(originalMapToCanvasPoint);
+  });
+});

--- a/packages/vtable-plugins/src/rotate-table.ts
+++ b/packages/vtable-plugins/src/rotate-table.ts
@@ -154,7 +154,6 @@ export function cancelTransform(this: ListTable, rotateDom: HTMLElement) {
   };
   const getMatrix = () => {
     const matrix = matrixAllocate.allocate(1, 0, 0, 1, 0, 0);
-    matrix.translate(x1, y1);
     return matrix;
   };
   registerGlobalEventTransformer(vglobal, this.getElement(), getMatrix, getRect as any, transformPointForCanvas);


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link

fix #5235

### 💡 Background and solution

After `RotateTablePlugin` rotated and restored a table, scrolling inside the table could also scroll the surrounding page.

When rotation was canceled, `cancelTransform` registered a translated matrix with the global event transformer. Because the matrix was not an identity matrix, VRender cloned the native `WheelEvent`. Calling `preventDefault()` on the transformed event therefore did not cancel the original browser event.

This change removes the residual translation when canceling rotation so the transformer receives an identity matrix and preserves the native wheel event. It also adds a regression test that verifies `preventDefault()` remains connected to the original event after restoring the table.

Validation:

- `@visactor/vtable-plugins`: 10 test suites and 60 tests passed.
- TypeScript compilation passed.
- `rush build -t @visactor/vtable-plugins` completed successfully with existing build warnings.
- The repository pre-push suite passed for the changed plugin package. It still reports two assertions in `packages/vtable-sheet/__tests__/nested-formula-engine.test.ts`; this pull request does not modify `packages/vtable-sheet`.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Prevent page scrolling when using the mouse wheel after restoring a rotated table. |
| 🇨🇳 Chinese | 修复表格旋转还原后，在表格内滚动鼠标滚轮时页面也会滚动的问题。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
