### PR TITLE
fix: refresh functional icons after theme updates

### DIFF
--- a/common/changes/@visactor/vtable/fix-issue-4816-functional-icon-theme_2026-07-27-15-36.json
+++ b/common/changes/@visactor/vtable/fix-issue-4816-functional-icon-theme_2026-07-27-15-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix: refresh functional icons after theme updates",
+      "type": "none",
+      "packageName": "@visactor/vtable"
+    }
+  ],
+  "packageName": "@visactor/vtable",
+  "email": "biukam.w@gmail.com"
+}

--- a/packages/vtable/__tests__/functional-icons-theme.test.ts
+++ b/packages/vtable/__tests__/functional-icons-theme.test.ts
@@ -1,0 +1,89 @@
+// @ts-nocheck
+import * as VTable from '../src';
+import { createDiv, removeDom } from './dom';
+
+global.__VERSION__ = 'none';
+
+describe('functional icon theme updates', () => {
+  let container: HTMLElement;
+  let table: VTable.ListTable;
+
+  const columns = [{ field: 'name', title: 'Name', sort: true, tree: true }];
+  const records = [{ name: 'Parent', children: [{ name: 'Child' }] }];
+
+  const createTable = () => {
+    container = createDiv();
+    container.style.width = '600px';
+    container.style.height = '400px';
+    table = new VTable.ListTable(container, {
+      columns,
+      records,
+      rowSeriesNumber: { dragOrder: true },
+      theme: {
+        functionalIconsStyle: {
+          sort_color: '#111111',
+          collapse_color: '#222222',
+          dragReorder_color: '#333333'
+        }
+      }
+    });
+  };
+
+  afterEach(() => {
+    table?.release();
+    removeDom(container);
+  });
+
+  test('refreshes functional icons after updateOption', () => {
+    createTable();
+
+    table.updateOption({
+      columns,
+      records,
+      rowSeriesNumber: { dragOrder: true },
+      theme: {
+        functionalIconsStyle: {
+          sort_color: '#123456',
+          collapse_color: '#234567',
+          dragReorder_color: '#345678'
+        }
+      }
+    });
+
+    expect(table.internalProps.headerHelper.normalIcon.svg).toContain('#123456');
+    expect(table.internalProps.bodyHelper.collapseIcon.svg).toContain('#234567');
+    expect(table.internalProps.rowSeriesNumberHelper.dragReorderIconName.svg).toContain('#345678');
+  });
+
+  test('refreshes functional icons after updateTheme', () => {
+    createTable();
+
+    table.updateTheme({
+      functionalIconsStyle: {
+        sort_color: '#456789',
+        collapse_color: '#56789a',
+        dragReorder_color: '#6789ab'
+      }
+    });
+
+    expect(table.internalProps.headerHelper.normalIcon.svg).toContain('#456789');
+    expect(table.internalProps.bodyHelper.collapseIcon.svg).toContain('#56789a');
+    expect(table.internalProps.rowSeriesNumberHelper.dragReorderIconName.svg).toContain('#6789ab');
+  });
+
+  test('refreshes functional icons after setting theme', () => {
+    createTable();
+
+    table.theme = {
+      functionalIconsStyle: {
+        sort_color: '#789abc',
+        collapse_color: '#89abcd',
+        dragReorder_color: '#9abcde'
+      }
+    };
+
+    expect(table.internalProps.headerHelper.normalIcon.svg).toContain('#789abc');
+    expect(table.internalProps.bodyHelper.collapseIcon.svg).toContain('#89abcd');
+    expect(table.internalProps.rowSeriesNumberHelper.dragReorderIconName.svg).toContain('#9abcde');
+  });
+});

--- a/packages/vtable/src/body-helper/body-helper.ts
+++ b/packages/vtable/src/body-helper/body-helper.ts
@@ -19,6 +19,10 @@ export class BodyHelper {
   _table: BaseTableAPI;
   constructor(_table: BaseTableAPI) {
     this._table = _table;
+    this.updateIcons();
+  }
+
+  updateIcons() {
     const regedIcons = registerIcons.get();
     //展开折叠按钮
     this.expandIcon = regedIcons[InternalIconName.expandIconName] as SvgIcon;

--- a/packages/vtable/src/core/BaseTable.ts
+++ b/packages/vtable/src/core/BaseTable.ts
@@ -503,7 +503,7 @@ export abstract class BaseTable extends EventTarget implements BaseTableAPI {
     internalProps.focusedTable = false;
     internalProps.theme = themes.of(options.theme ?? themes.DEFAULT); //原来在listTable文件中
     internalProps.theme.isPivot = this.isPivotTable();
-    setIconColor(internalProps.theme.functionalIconsStyle);
+    this._updateFunctionalIcons();
     if (container) {
       // 先清空
       if (clearDOM) {
@@ -2938,7 +2938,7 @@ export abstract class BaseTable extends EventTarget implements BaseTableAPI {
 
     internalProps.theme = themes.of(options.theme ?? themes.DEFAULT);
     internalProps.theme.isPivot = this.isPivotTable();
-    setIconColor(internalProps.theme.functionalIconsStyle);
+    this._updateFunctionalIcons();
     this.scenegraph.updateStageBackground();
     // this._updateSize();
     //设置是否自动撑开的配置
@@ -3783,6 +3783,12 @@ export abstract class BaseTable extends EventTarget implements BaseTableAPI {
   /**
    * 获取当前使用的主题
    */
+  private _updateFunctionalIcons() {
+    setIconColor(this.internalProps.theme.functionalIconsStyle);
+    this.internalProps.headerHelper?.updateIcons();
+    this.internalProps.bodyHelper?.updateIcons();
+    this.internalProps.rowSeriesNumberHelper?.updateIcons();
+  }
   get theme(): TableTheme {
     return this.internalProps.theme;
   }
@@ -3790,7 +3796,7 @@ export abstract class BaseTable extends EventTarget implements BaseTableAPI {
     this.internalProps.theme = themes.of(theme ?? themes.DEFAULT);
     this.internalProps.theme.isPivot = this.isPivotTable();
     this.options.theme = theme;
-    setIconColor(this.internalProps.theme.functionalIconsStyle);
+    this._updateFunctionalIcons();
   }
   /**
    * 设置主题
@@ -3799,7 +3805,7 @@ export abstract class BaseTable extends EventTarget implements BaseTableAPI {
     const oldHoverState = { col: this.stateManager.hover.cellPos.col, row: this.stateManager.hover.cellPos.row };
     this.internalProps.theme = themes.of(theme ?? themes.DEFAULT);
     this.internalProps.theme.isPivot = this.isPivotTable();
-    setIconColor(this.internalProps.theme.functionalIconsStyle);
+    this._updateFunctionalIcons();
     this.options.theme = theme;
     this.scenegraph.updateComponent();
     this.scenegraph.updateStageBackground();

--- a/packages/vtable/src/core/row-series-number-helper.ts
+++ b/packages/vtable/src/core/row-series-number-helper.ts
@@ -17,6 +17,10 @@ export class RowSeriesNumberHelper {
   _table: BaseTableAPI;
   constructor(_table: BaseTableAPI) {
     this._table = _table;
+    this.updateIcons();
+  }
+
+  updateIcons() {
     const regedIcons = registerIcons.get();
 
     this.dragReorderIconName = regedIcons[InternalIconName.dragReorderIconName] as SvgIcon;

--- a/packages/vtable/src/header-helper/header-helper.ts
+++ b/packages/vtable/src/header-helper/header-helper.ts
@@ -38,6 +38,10 @@ export class HeaderHelper {
   _table: BaseTableAPI;
   constructor(_table: BaseTableAPI) {
     this._table = _table;
+    this.updateIcons();
+  }
+
+  updateIcons() {
     const regedIcons = registerIcons.get();
     //pin默认值
     this.freezeIcon = regedIcons[InternalIconName.freezeIconName] as SvgIcon;


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link

Fixes #4816

### 💡 Background and solution

Built-in functional icons are regenerated when the theme changes, but `HeaderHelper`, `BodyHelper`, and `RowSeriesNumberHelper` kept the icon objects cached during table initialization. As a result, rebuilding the scenegraph after `updateOption()`, `updateTheme()`, or assigning `theme` continued to use the previous icon colors.

This change adds an `updateIcons()` method to the three helpers and refreshes their cached icon definitions immediately after applying functional icon colors.

### ✅ Verification

- `npm test -- --runInBand __tests__/functional-icons-theme.test.ts __tests__/listTable.test.ts __tests__/options/listTable-icon.test.ts`: 15 tests passed
- `npm run compile`: passed
- `node common/scripts/install-run-rush.js build -t @visactor/vtable`: completed successfully with existing build warnings
- The repository-wide pre-push test was also attempted. It remains blocked by unrelated existing failures in `vtable-sheet` dependency/formula tests and the `video-cell-first-frame.test.ts` environment tests.

### 📝 Changelog

| Language | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Refresh built-in functional icon colors after table theme updates. |
| 🇨🇳 Chinese | 修复表格主题更新后内置功能图标颜色未刷新的问题。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough