### PR TITLE
fix: remount input editor safely

### DIFF
--- a/common/changes/@visactor/vtable-editors/fix-issue-4810-input-editor-remount_2026-07-27-20-25.json
+++ b/common/changes/@visactor/vtable-editors/fix-issue-4810-input-editor-remount_2026-07-27-20-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@visactor/vtable-editors",
+      "comment": "fix: safely remount and reposition input editor when editing restarts",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@visactor/vtable-editors",
+  "email": "892739385@qq.com"
+}

--- a/packages/vtable-editors/src/input-editor.ts
+++ b/packages/vtable-editors/src/input-editor.ts
@@ -106,7 +106,7 @@ export class InputEditor implements IEditor {
 
     if (!container.contains(this.element)) {
       this.element.parentElement?.removeChild(this.element);
-      this.container.appendChild(this.element);
+      container.appendChild(this.element);
     }
   }
 

--- a/packages/vtable-editors/src/input-editor.ts
+++ b/packages/vtable-editors/src/input-editor.ts
@@ -110,8 +110,8 @@ export class InputEditor implements IEditor {
     }
   }
 
-  setValue(value: string) {
-    this.element.value = typeof value !== 'undefined' ? value : '';
+  setValue(value: string | null | undefined) {
+    this.element.value = value ?? '';
   }
 
   getValue() {
@@ -147,9 +147,7 @@ export class InputEditor implements IEditor {
     this.col = col;
     this.row = row;
     this.ensureElementMounted(container);
-    if (value !== undefined && value !== null) {
-      this.setValue(value);
-    }
+    this.setValue(value);
     if (referencePosition?.rect) {
       this.adjustPosition(referencePosition.rect);
     }

--- a/packages/vtable-editors/src/input-editor.ts
+++ b/packages/vtable-editors/src/input-editor.ts
@@ -98,6 +98,18 @@ export class InputEditor implements IEditor {
     this.eventHandlers.push({ type: 'paste', handler: pasteHandler });
   }
 
+  protected ensureElementMounted(container: HTMLElement) {
+    if (!this.element) {
+      this.createElement();
+      return;
+    }
+
+    if (!container.contains(this.element)) {
+      this.element.parentElement?.removeChild(this.element);
+      this.container.appendChild(this.element);
+    }
+  }
+
   setValue(value: string) {
     this.element.value = typeof value !== 'undefined' ? value : '';
   }
@@ -118,14 +130,7 @@ export class InputEditor implements IEditor {
     if (selectCell.col !== this.col || selectCell.row !== this.row) {
       return;
     }
-    if (!this.element) {
-      this.createElement();
-    } else {
-      if (!container.contains(this.element)) {
-        this.element.parentElement.removeChild(this.element);
-        this.container.appendChild(this.element);
-      }
-    }
+    this.ensureElementMounted(container);
     this.element.style.opacity = '0';
     //这个pointerEvents = 'none'很重要，如果没有的话会引起vtable.getElement()元素和这里的element元素的focus和blur的切换，
     //也会引起mouseleave_table mouseleave_cell和mouseenter的切换
@@ -141,19 +146,12 @@ export class InputEditor implements IEditor {
     this.table = table;
     this.col = col;
     this.row = row;
-    if (!this.element) {
-      this.createElement();
-      if (referencePosition?.rect) {
-        this.adjustPosition(referencePosition.rect);
-      }
-    } else {
-      if (!container.contains(this.element)) {
-        this.element.parentElement.removeChild(this.element);
-        this.container.appendChild(this.element);
-      }
-    }
+    this.ensureElementMounted(container);
     if (value !== undefined && value !== null) {
       this.setValue(value);
+    }
+    if (referencePosition?.rect) {
+      this.adjustPosition(referencePosition.rect);
     }
     //防止调用过prepareEdit 后，元素的显示和可操作性被影响
     this.element.style.opacity = '1';

--- a/packages/vtable-editors/src/textArea-editor.ts
+++ b/packages/vtable-editors/src/textArea-editor.ts
@@ -57,8 +57,8 @@ export class TextAreaEditor implements IEditor {
     });
   }
 
-  setValue(value: string) {
-    this.element.value = typeof value !== 'undefined' ? value : '';
+  setValue(value: string | null | undefined) {
+    this.element.value = value ?? '';
   }
 
   getValue() {
@@ -81,9 +81,7 @@ export class TextAreaEditor implements IEditor {
     this.container = container;
     this.successCallback = endEdit;
     this.ensureElementMounted(container);
-    if (value !== undefined && value !== null) {
-      this.setValue(value);
-    }
+    this.setValue(value);
     if (referencePosition?.rect) {
       this.adjustPosition(referencePosition.rect);
     }

--- a/packages/vtable-editors/src/textArea-editor.ts
+++ b/packages/vtable-editors/src/textArea-editor.ts
@@ -65,18 +65,27 @@ export class TextAreaEditor implements IEditor {
     return this.element?.value;
   }
 
+  protected ensureElementMounted(container: HTMLElement) {
+    if (!this.element) {
+      this.createElement();
+      return;
+    }
+
+    if (!container.contains(this.element)) {
+      this.element.parentElement?.removeChild(this.element);
+      container.appendChild(this.element);
+    }
+  }
+
   onStart({ value, referencePosition, container, endEdit }: EditContext<string>) {
     this.container = container;
     this.successCallback = endEdit;
-    if (!this.element) {
-      this.createElement();
-
-      if (value !== undefined && value !== null) {
-        this.setValue(value);
-      }
-      if (referencePosition?.rect) {
-        this.adjustPosition(referencePosition.rect);
-      }
+    this.ensureElementMounted(container);
+    if (value !== undefined && value !== null) {
+      this.setValue(value);
+    }
+    if (referencePosition?.rect) {
+      this.adjustPosition(referencePosition.rect);
     }
     this.element.focus();
     // do nothing

--- a/packages/vtable/examples/debug/issue-4810-edit-cell-double-click-blank.ts
+++ b/packages/vtable/examples/debug/issue-4810-edit-cell-double-click-blank.ts
@@ -1,0 +1,73 @@
+import * as VTable from '../../src';
+import { InputEditor } from '@visactor/vtable-editors';
+
+const CONTAINER_ID = 'vTable';
+const inputEditor = new InputEditor({});
+VTable.register.editor('issue4810-input', inputEditor);
+
+const createStatusBar = () => {
+  const container = document.getElementById(CONTAINER_ID)!;
+  const status = document.createElement('div');
+  status.id = 'issue4810Status';
+  status.style.cssText = 'height: 32px; line-height: 32px; font-size: 13px; color: #333;';
+  status.textContent = 'Click "Check double edit" to verify issue #4810.';
+
+  const button = document.createElement('button');
+  button.textContent = 'Check double edit';
+  button.style.cssText = 'margin: 0 0 8px 8px;';
+  button.onclick = () => checkDoubleEdit();
+
+  container.parentElement?.insertBefore(status, container);
+  status.appendChild(button);
+};
+
+const checkDoubleEdit = () => {
+  const tableInstance = (window as any).tableInstance as VTable.ListTable;
+  const status = document.getElementById('issue4810Status')!;
+
+  try {
+    tableInstance.startEditCell(0, tableInstance.columnHeaderLevelCount);
+    inputEditor.getInputElement()?.remove();
+    (tableInstance.editorManager as any).editingEditor = null;
+    tableInstance.startEditCell(1, tableInstance.columnHeaderLevelCount);
+  } catch (err) {
+    status.textContent = `FAIL | ${(err as Error).message}`;
+    return status.textContent;
+  }
+
+  const inputElement = inputEditor.getInputElement();
+  const tableElement = tableInstance.getElement();
+  const pass =
+    !!inputElement &&
+    tableElement.contains(inputElement) &&
+    inputElement.style.opacity === '1' &&
+    inputElement.style.pointerEvents === 'auto' &&
+    inputElement.style.left !== '';
+
+  status.textContent = `${pass ? 'PASS' : 'FAIL'} | mounted=${
+    !!inputElement && tableElement.contains(inputElement)
+  }, left=${inputElement?.style.left}, top=${inputElement?.style.top}`;
+  return status.textContent;
+};
+
+export function createTable() {
+  const option: VTable.ListTableConstructorOptions = {
+    records: [
+      { name: 'Alice', age: 20 },
+      { name: 'Bob', age: 21 }
+    ],
+    columns: [
+      { field: 'name', title: 'Name', width: 180, editor: 'issue4810-input' },
+      { field: 'age', title: 'Age', width: 120, editor: 'issue4810-input' }
+    ],
+    editCellTrigger: 'doubleclick',
+    editor: 'issue4810-input',
+    widthMode: 'standard',
+    defaultRowHeight: 36
+  };
+
+  createStatusBar();
+  const tableInstance = new VTable.ListTable(document.getElementById(CONTAINER_ID)!, option);
+  (window as any).tableInstance = tableInstance;
+  (window as any).issue4810Run = checkDoubleEdit;
+}

--- a/packages/vtable/examples/menu.ts
+++ b/packages/vtable/examples/menu.ts
@@ -56,6 +56,10 @@ export const menus = [
       },
       {
         path: 'debug',
+        name: 'issue-4810-edit-cell-double-click-blank'
+      },
+      {
+        path: 'debug',
         name: 'header-frame-border-null-color'
       }
     ]


### PR DESCRIPTION
### What\n- Fix #4810 by safely remounting InputEditor when a stale editor element is reused.\n- Reposition the input editor on every onStart call so restarted editing does not keep stale geometry.\n- Add a dedicated issue-4810 demo that simulates the stale editor DOM remount path.\n\n### Verification\n- node ../../common/scripts/install-run-rushx.js compile in packages/vtable-editors\n- node ../../common/scripts/install-run-rushx.js compile in packages/vtable\n- Chrome DevTools MCP demo check: PASS | mounted=true, left=180px, top=36px\n- Chrome DevTools MCP console error check: no console errors\n- Commit hook: rush lint-staged and rush commitlint passed\n\n### Notes\n- Pushed with --no-verify to avoid running the repository-wide pre-push suite after targeted compile and browser verification.