### PR TITLE
fix(vue-vtable): keep custom layout off scrollbars

### DIFF
--- a/packages/vue-vtable/demo/src/App.vue
+++ b/packages/vue-vtable/demo/src/App.vue
@@ -20,6 +20,7 @@ import ListTableDes from './table/gramatical/composition/ListTable-destruction.v
 import ListTableCustom from './table/gramatical/composition/ListTable-custom.vue';
 import ListTableCustomHover from './table/gramatical/composition/ListTable-custom-hover.vue';
 import Issue5150CustomLayoutSort from './table/gramatical/composition/Issue5150CustomLayoutSort.vue';
+import Issue5157CustomLayoutScrollbar from './table/gramatical/composition/Issue5157CustomLayoutScrollbar.vue';
 import ListTableVFor from './table/gramatical/options/ListTable-v-for.vue';
 
 import PivotTable from './table/gramatical/options/PivotTable.vue';
@@ -51,8 +52,9 @@ import singleRadio from './table/single/single-radio.vue';
   <!-- gramatical -->
   <!-- ---------- -->
 
-  <ListTable />
+  <!-- <ListTable /> -->
   <!-- <Issue5150CustomLayoutSort /> -->
+  <Issue5157CustomLayoutScrollbar />
   <!-- <ListTableEditor /> -->
   <!-- <ListTableEditorArco /> -->
   <!-- <ListTableEditorRender /> -->

--- a/packages/vue-vtable/demo/src/table/gramatical/composition/Issue5157CustomLayoutScrollbar.vue
+++ b/packages/vue-vtable/demo/src/table/gramatical/composition/Issue5157CustomLayoutScrollbar.vue
@@ -3,35 +3,37 @@
     <button @click="check">Check scrollbar hit area</button>
     <span>{{ state }}</span>
   </div>
-  <vue-list-table ref="tableRef" :options="tableOptions">
-    <ListColumn field="name" title="Name" width="180">
-      <template #customLayout="{ width, height, record, row }">
-        <Group
-          :width="width"
-          :height="height"
-          :vue="{
-            element: renderAction(record, row, 'Frozen'),
-            pointerEvents: true,
-            id: `issue5157-frozen-${row}`
-          }"
-        />
-      </template>
-    </ListColumn>
-    <ListColumn field="value" title="Value" width="180" />
-    <ListColumn field="action" title="Action" width="260">
-      <template #customLayout="{ width, height, record, row }">
-        <Group
-          :width="width"
-          :height="height"
-          :vue="{
-            element: renderAction(record, row, 'Action'),
-            pointerEvents: true,
-            id: `issue5157-body-${row}`
-          }"
-        />
-      </template>
-    </ListColumn>
-  </vue-list-table>
+  <div class="issue5157-table">
+    <vue-list-table ref="tableRef" :options="tableOptions">
+      <ListColumn field="name" title="Name" width="180">
+        <template #customLayout="{ width, height, record, row }">
+          <Group
+            :width="width"
+            :height="height"
+            :vue="{
+              element: renderAction(record, row, 'Frozen'),
+              pointerEvents: true,
+              id: `issue5157-frozen-${row}`
+            }"
+          />
+        </template>
+      </ListColumn>
+      <ListColumn field="value" title="Value" width="180" />
+      <ListColumn field="action" title="Action" width="260">
+        <template #customLayout="{ width, height, record, row }">
+          <Group
+            :width="width"
+            :height="height"
+            :vue="{
+              element: renderAction(record, row, 'Action'),
+              pointerEvents: true,
+              id: `issue5157-body-${row}`
+            }"
+          />
+        </template>
+      </ListColumn>
+    </vue-list-table>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -87,28 +89,38 @@ function renderAction(record: any, row: number, label: string) {
 
 function check() {
   const table = tableRef.value?.vTableInstance;
-  const bodyDom = document.querySelector<HTMLElement>('[id^="vue_issue5157-body-"]');
-  const frozenDom = document.querySelector<HTMLElement>('[id^="vue_issue5157-frozen-"]');
-  if (!table || !bodyDom || !frozenDom) {
+  const bodyDoms = Array.from(document.querySelectorAll<HTMLElement>('[id^="vue_issue5157-body-"]'));
+  const frozenDoms = Array.from(document.querySelectorAll<HTMLElement>('[id^="vue_issue5157-frozen-"]'));
+  if (!table || !bodyDoms.length || !frozenDoms.length) {
     state.value = 'FAIL | missing table or dom';
     return { pass: false };
   }
 
-  const bodyRect = bodyDom.getBoundingClientRect();
-  const frozenRect = frozenDom.getBoundingClientRect();
+  const firstBodyRect = bodyDoms[0].getBoundingClientRect();
+  const firstFrozenRect = frozenDoms[0].getBoundingClientRect();
   const tableRect = table.getElement().getBoundingClientRect();
-  const scrollbarLeft = tableRect.left + table.tableNoFrameWidth - 16;
-  const frozenScrollbarTop = tableRect.top + Math.min(table.tableNoFrameHeight, table.getAllRowsHeight()) - 16;
-  const pass = bodyRect.right <= scrollbarLeft + 0.5 && frozenRect.bottom <= frozenScrollbarTop + 0.5;
+  const scrollbarSize = table.theme?.scrollStyle?.width ?? 16;
+  const scrollbarLeft = tableRect.left + table.tableNoFrameWidth - scrollbarSize;
+  const frozenScrollbarTop = tableRect.top + Math.min(table.tableNoFrameHeight, table.getAllRowsHeight()) - scrollbarSize;
+  const clippedFrozenDoms = frozenDoms.filter(dom => {
+    const rect = dom.getBoundingClientRect();
+    return rect.bottom > frozenScrollbarTop && getComputedStyle(dom).clipPath !== 'none';
+  });
+  const pass =
+    firstBodyRect.right <= scrollbarLeft + 0.5 &&
+    firstFrozenRect.bottom <= frozenScrollbarTop + 0.5 &&
+    clippedFrozenDoms.length > 0;
   state.value =
-    `${pass ? 'PASS' : 'FAIL'} | bodyRight=${Math.round(bodyRect.right)} scrollbarLeft=${Math.round(scrollbarLeft)} ` +
-    `frozenBottom=${Math.round(frozenRect.bottom)} frozenScrollbarTop=${Math.round(frozenScrollbarTop)}`;
+    `${pass ? 'PASS' : 'FAIL'} | bodyRight=${Math.round(firstBodyRect.right)} scrollbarLeft=${Math.round(scrollbarLeft)} ` +
+    `frozenBottom=${Math.round(firstFrozenRect.bottom)} frozenScrollbarTop=${Math.round(frozenScrollbarTop)} ` +
+    `clippedFrozen=${clippedFrozenDoms.length}`;
   return {
     pass,
-    bodyRight: bodyRect.right,
+    bodyRight: firstBodyRect.right,
     scrollbarLeft,
-    frozenBottom: frozenRect.bottom,
+    frozenBottom: firstFrozenRect.bottom,
     frozenScrollbarTop,
+    clippedFrozenCount: clippedFrozenDoms.length,
     frozenOffset: table.getFrozenColsOffset?.()
   };
 }
@@ -130,7 +142,7 @@ nextTick(() => {
   font-size: 12px;
 }
 
-:deep(.vtable) {
+.issue5157-table {
   width: 620px;
   height: 360px;
 }

--- a/packages/vue-vtable/demo/src/table/gramatical/composition/Issue5157CustomLayoutScrollbar.vue
+++ b/packages/vue-vtable/demo/src/table/gramatical/composition/Issue5157CustomLayoutScrollbar.vue
@@ -4,7 +4,19 @@
     <span>{{ state }}</span>
   </div>
   <vue-list-table ref="tableRef" :options="tableOptions">
-    <ListColumn field="name" title="Name" width="180" />
+    <ListColumn field="name" title="Name" width="180">
+      <template #customLayout="{ width, height, record, row }">
+        <Group
+          :width="width"
+          :height="height"
+          :vue="{
+            element: renderAction(record, row, 'Frozen'),
+            pointerEvents: true,
+            id: `issue5157-frozen-${row}`
+          }"
+        />
+      </template>
+    </ListColumn>
     <ListColumn field="value" title="Value" width="180" />
     <ListColumn field="action" title="Action" width="260">
       <template #customLayout="{ width, height, record, row }">
@@ -12,9 +24,9 @@
           :width="width"
           :height="height"
           :vue="{
-            element: renderAction(record, row),
+            element: renderAction(record, row, 'Action'),
             pointerEvents: true,
-            id: `issue5157-${row}`
+            id: `issue5157-body-${row}`
           }"
         />
       </template>
@@ -43,6 +55,9 @@ const tableOptions = ref({
   heightMode: 'standard',
   defaultRowHeight: 44,
   defaultHeaderRowHeight: 40,
+  frozenColCount: 1,
+  scrollFrozenCols: true,
+  maxFrozenWidth: 80,
   theme: {
     ...VTable.themes.DEFAULT,
     scrollStyle: {
@@ -56,7 +71,7 @@ const tableOptions = ref({
   }
 });
 
-function renderAction(record: any, row: number) {
+function renderAction(record: any, row: number, label: string) {
   return h(
     'button',
     {
@@ -66,26 +81,36 @@ function renderAction(record: any, row: number) {
         state.value = `clicked ${record.id}`;
       }
     },
-    `Action ${record.id}`
+    `${label} ${record.id}`
   );
 }
 
 function check() {
   const table = tableRef.value?.vTableInstance;
-  const dom = document.querySelector<HTMLElement>('[id^="vue_issue5157-"]');
-  if (!table || !dom) {
+  const bodyDom = document.querySelector<HTMLElement>('[id^="vue_issue5157-body-"]');
+  const frozenDom = document.querySelector<HTMLElement>('[id^="vue_issue5157-frozen-"]');
+  if (!table || !bodyDom || !frozenDom) {
     state.value = 'FAIL | missing table or dom';
     return { pass: false };
   }
 
-  const domRect = dom.getBoundingClientRect();
+  const bodyRect = bodyDom.getBoundingClientRect();
+  const frozenRect = frozenDom.getBoundingClientRect();
   const tableRect = table.getElement().getBoundingClientRect();
   const scrollbarLeft = tableRect.left + table.tableNoFrameWidth - 16;
-  const pass = domRect.right <= scrollbarLeft + 0.5;
-  state.value = `${pass ? 'PASS' : 'FAIL'} | domRight=${Math.round(domRect.right)} scrollbarLeft=${Math.round(
-    scrollbarLeft
-  )}`;
-  return { pass, domRight: domRect.right, scrollbarLeft };
+  const frozenScrollbarTop = tableRect.top + Math.min(table.tableNoFrameHeight, table.getAllRowsHeight()) - 16;
+  const pass = bodyRect.right <= scrollbarLeft + 0.5 && frozenRect.bottom <= frozenScrollbarTop + 0.5;
+  state.value =
+    `${pass ? 'PASS' : 'FAIL'} | bodyRight=${Math.round(bodyRect.right)} scrollbarLeft=${Math.round(scrollbarLeft)} ` +
+    `frozenBottom=${Math.round(frozenRect.bottom)} frozenScrollbarTop=${Math.round(frozenScrollbarTop)}`;
+  return {
+    pass,
+    bodyRight: bodyRect.right,
+    scrollbarLeft,
+    frozenBottom: frozenRect.bottom,
+    frozenScrollbarTop,
+    frozenOffset: table.getFrozenColsOffset?.()
+  };
 }
 
 nextTick(() => {

--- a/packages/vue-vtable/demo/src/table/gramatical/composition/Issue5157CustomLayoutScrollbar.vue
+++ b/packages/vue-vtable/demo/src/table/gramatical/composition/Issue5157CustomLayoutScrollbar.vue
@@ -1,0 +1,121 @@
+<template>
+  <div class="toolbar">
+    <button @click="check">Check scrollbar hit area</button>
+    <span>{{ state }}</span>
+  </div>
+  <vue-list-table ref="tableRef" :options="tableOptions">
+    <ListColumn field="name" title="Name" width="180" />
+    <ListColumn field="value" title="Value" width="180" />
+    <ListColumn field="action" title="Action" width="260">
+      <template #customLayout="{ width, height, record, row }">
+        <Group
+          :width="width"
+          :height="height"
+          :vue="{
+            element: renderAction(record, row),
+            pointerEvents: true,
+            id: `issue5157-${row}`
+          }"
+        />
+      </template>
+    </ListColumn>
+  </vue-list-table>
+</template>
+
+<script setup lang="ts">
+import { h, nextTick, ref } from 'vue';
+import { Group, ListColumn } from '../../../../../src/components/index';
+import * as VTable from '../../../../../../vtable/src/index';
+
+const tableRef = ref();
+const state = ref('READY');
+
+const records = Array.from({ length: 100 }, (_, index) => ({
+  id: index + 1,
+  name: `row-${index + 1}`,
+  value: `value-${index + 1}`,
+  action: 'clickable'
+}));
+
+const tableOptions = ref({
+  records,
+  widthMode: 'standard',
+  heightMode: 'standard',
+  defaultRowHeight: 44,
+  defaultHeaderRowHeight: 40,
+  theme: {
+    ...VTable.themes.DEFAULT,
+    scrollStyle: {
+      ...VTable.themes.DEFAULT.scrollStyle,
+      visible: 'always',
+      width: 16
+    }
+  },
+  customConfig: {
+    createReactContainer: true
+  }
+});
+
+function renderAction(record: any, row: number) {
+  return h(
+    'button',
+    {
+      class: 'action-button',
+      'data-row': row,
+      onClick: () => {
+        state.value = `clicked ${record.id}`;
+      }
+    },
+    `Action ${record.id}`
+  );
+}
+
+function check() {
+  const table = tableRef.value?.vTableInstance;
+  const dom = document.querySelector<HTMLElement>('[id^="vue_issue5157-"]');
+  if (!table || !dom) {
+    state.value = 'FAIL | missing table or dom';
+    return { pass: false };
+  }
+
+  const domRect = dom.getBoundingClientRect();
+  const tableRect = table.getElement().getBoundingClientRect();
+  const scrollbarLeft = tableRect.left + table.tableNoFrameWidth - 16;
+  const pass = domRect.right <= scrollbarLeft + 0.5;
+  state.value = `${pass ? 'PASS' : 'FAIL'} | domRight=${Math.round(domRect.right)} scrollbarLeft=${Math.round(
+    scrollbarLeft
+  )}`;
+  return { pass, domRight: domRect.right, scrollbarLeft };
+}
+
+nextTick(() => {
+  setTimeout(check, 0);
+});
+
+(window as any).issue5157Check = check;
+</script>
+
+<style scoped>
+.toolbar {
+  height: 36px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 8px;
+  font-size: 12px;
+}
+
+:deep(.vtable) {
+  width: 620px;
+  height: 360px;
+}
+
+.action-button {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: #e8f3ff;
+  color: #1664ff;
+  cursor: pointer;
+}
+</style>

--- a/packages/vue-vtable/src/components/custom/vtable-vue-attribute-plugin.ts
+++ b/packages/vue-vtable/src/components/custom/vtable-vue-attribute-plugin.ts
@@ -489,6 +489,7 @@ export class VTableVueAttributePlugin extends HtmlAttributePlugin implements IPl
     const { vue: options, width, height, visible, display, ...rest } = attribute || {};
     const { x: left, y: top } = this.calculatePosition(graphic, options.anchorType);
     const { left: offsetX, top: offsetTop } = this.calculateOffset(stage, nativeContainer, left, top);
+    const { safeWidth, safeHeight } = this.getScrollbarSafeSize(graphic, offsetX, offsetTop, width, height, options);
 
     const { id } = this.getGraphicOptions(graphic) || {};
     const record = id ? this.htmlMap[id] : null;
@@ -499,10 +500,6 @@ export class VTableVueAttributePlugin extends HtmlAttributePlugin implements IPl
     // 位置变化检查
     const positionChanged =
       !record.lastPosition || record.lastPosition.x !== offsetX || record.lastPosition.y !== offsetTop;
-    if (!positionChanged) {
-      // 位置没有变化，无需更新样式
-      return;
-    }
 
     // 默认自定义区域内也可带动表格画布滚动
     const { pointerEvents } = options;
@@ -510,8 +507,8 @@ export class VTableVueAttributePlugin extends HtmlAttributePlugin implements IPl
     // 单元格样式
     const style = this.convertCellStyle(graphic);
     Object.assign(calculateStyle, {
-      width: `${width}px`,
-      height: `${height}px`,
+      width: `${safeWidth}px`,
+      height: `${safeHeight}px`,
       overflow: 'hidden',
       ...(style || {}),
       ...(rest || {}),
@@ -546,6 +543,38 @@ export class VTableVueAttributePlugin extends HtmlAttributePlugin implements IPl
 
       record.lastStyle = calculateStyle;
     }
+    record.lastPosition = positionChanged ? { x: offsetX, y: offsetTop } : record.lastPosition;
+  }
+
+  private getScrollbarSafeSize(
+    graphic: IGraphic,
+    offsetX: number,
+    offsetTop: number,
+    width: number,
+    height: number,
+    options: any
+  ) {
+    const pointerEvents = options?.pointerEvents === true ? 'all' : options?.pointerEvents || 'none';
+    const table = getTargetGroup(graphic)?.stage?.table;
+    const scrollStyle = table?.theme?.scrollStyle;
+    const barToSide = scrollStyle?.barToSide ?? false;
+    let safeWidth = width;
+    let safeHeight = height;
+
+    if (pointerEvents !== 'none' && table && !barToSide) {
+      const verticalVisible = scrollStyle?.verticalVisible ?? scrollStyle?.visible;
+      const horizontalVisible = scrollStyle?.horizontalVisible ?? scrollStyle?.visible;
+      const hasVerticalScrollBar = verticalVisible !== 'none' && table.getAllRowsHeight() > table.tableNoFrameHeight;
+      const hasHorizontalScrollBar = horizontalVisible !== 'none' && table.getAllColsWidth() > table.tableNoFrameWidth;
+      const scrollBarSize = scrollStyle?.width ?? 7;
+      const maxRight = table.tableNoFrameWidth - (hasVerticalScrollBar ? scrollBarSize : 0);
+      const maxBottom = table.tableNoFrameHeight - (hasHorizontalScrollBar ? scrollBarSize : 0);
+
+      safeWidth = Math.max(0, Math.min(width, maxRight - offsetX));
+      safeHeight = Math.max(0, Math.min(height, maxBottom - offsetTop));
+    }
+
+    return { safeWidth, safeHeight };
   }
 
   /**

--- a/packages/vue-vtable/src/components/custom/vtable-vue-attribute-plugin.ts
+++ b/packages/vue-vtable/src/components/custom/vtable-vue-attribute-plugin.ts
@@ -513,6 +513,7 @@ export class VTableVueAttributePlugin extends HtmlAttributePlugin implements IPl
     // 默认自定义区域内也可带动表格画布滚动
     const { pointerEvents } = options;
     const calculateStyle = this.parseDefaultStyleFromGraphic(graphic);
+    const clipStyle = this.getScrollbarClipStyle(width, height, safeWidth, safeHeight);
     // 单元格样式
     const style = this.convertCellStyle(graphic);
     Object.assign(calculateStyle, {
@@ -521,6 +522,7 @@ export class VTableVueAttributePlugin extends HtmlAttributePlugin implements IPl
       overflow: 'hidden',
       ...(style || {}),
       ...(rest || {}),
+      ...clipStyle,
       transform: `translate(${offsetX}px, ${offsetTop}px)`,
       boxSizing: 'border-box',
       display: visible !== false ? display || 'block' : 'none',
@@ -669,6 +671,19 @@ export class VTableVueAttributePlugin extends HtmlAttributePlugin implements IPl
     }
 
     return { safeWidth, safeHeight };
+  }
+
+  private getScrollbarClipStyle(width: number, height: number, safeWidth: number, safeHeight: number) {
+    if (safeWidth >= width && safeHeight >= height) {
+      return { clipPath: 'none' };
+    }
+
+    const right = safeWidth < width ? `calc(100% - ${safeWidth}px)` : '0px';
+    const bottom = safeHeight < height ? `calc(100% - ${safeHeight}px)` : '0px';
+
+    return {
+      clipPath: `inset(0 ${right} ${bottom} 0)`
+    };
   }
 
   private getBodyHorizontalScrollRange(table: any) {

--- a/packages/vue-vtable/src/components/custom/vtable-vue-attribute-plugin.ts
+++ b/packages/vue-vtable/src/components/custom/vtable-vue-attribute-plugin.ts
@@ -575,9 +575,11 @@ export class VTableVueAttributePlugin extends HtmlAttributePlugin implements IPl
     if (pointerEvents !== 'none' && table && !barToSide) {
       const verticalVisible = scrollStyle?.verticalVisible ?? scrollStyle?.visible;
       const horizontalVisible = scrollStyle?.horizontalVisible ?? scrollStyle?.visible;
-      const hasVerticalScrollBar = verticalVisible !== 'none' && table.getAllRowsHeight() > table.tableNoFrameHeight;
+      const sizeTolerance = this.getScrollSizeTolerance(table);
+      const hasVerticalScrollBar =
+        verticalVisible !== 'none' && table.getAllRowsHeight() > table.tableNoFrameHeight + sizeTolerance;
       const hasHorizontalScrollBar =
-        horizontalVisible !== 'none' && this.getBodyHorizontalScrollRange(table) > this.getScrollSizeTolerance(table);
+        horizontalVisible !== 'none' && this.getBodyHorizontalScrollRange(table) > sizeTolerance;
       const scrollBarSize = scrollStyle?.width ?? 7;
       const groupX = table.scenegraph?.tableGroup?.attribute?.x ?? 0;
       const groupY = table.scenegraph?.tableGroup?.attribute?.y ?? 0;

--- a/packages/vue-vtable/src/components/custom/vtable-vue-attribute-plugin.ts
+++ b/packages/vue-vtable/src/components/custom/vtable-vue-attribute-plugin.ts
@@ -586,6 +586,7 @@ export class VTableVueAttributePlugin extends HtmlAttributePlugin implements IPl
       const hoverOn = scrollStyle?.hoverOn;
       const domRight = offsetX + width;
       const domBottom = offsetTop + height;
+      const ignoreFrozenCols = scrollStyle?.ignoreFrozenCols ?? false;
 
       if (hasVerticalScrollBar) {
         const verticalLeft =
@@ -611,16 +612,7 @@ export class VTableVueAttributePlugin extends HtmlAttributePlugin implements IPl
         }
       }
 
-      if (hasHorizontalScrollBar) {
-        const ignoreFrozenCols = scrollStyle?.ignoreFrozenCols ?? false;
-        const horizontalLeft = ignoreFrozenCols
-          ? !hoverOn
-            ? groupX
-            : 0
-          : table.getFrozenColsWidth() + (!hoverOn ? groupX : 0);
-        const horizontalWidth = ignoreFrozenCols
-          ? table.tableNoFrameWidth
-          : table.tableNoFrameWidth - table.getFrozenColsWidth() - table.getRightFrozenColsWidth();
+      const clipHorizontalScrollbar = (horizontalLeft: number, horizontalWidth: number) => {
         const horizontalTop =
           Math.min(table.tableNoFrameHeight, table.getAllRowsHeight()) - (hoverOn ? scrollBarSize : -groupY);
         const horizontalRight = horizontalLeft + horizontalWidth;
@@ -640,6 +632,39 @@ export class VTableVueAttributePlugin extends HtmlAttributePlugin implements IPl
         ) {
           safeHeight = Math.max(0, Math.min(height, horizontalDomTop - offsetTop));
         }
+      };
+
+      if (hasHorizontalScrollBar) {
+        const horizontalLeft = ignoreFrozenCols
+          ? !hoverOn
+            ? groupX
+            : 0
+          : table.getFrozenColsWidth() + (!hoverOn ? groupX : 0);
+        const horizontalWidth = ignoreFrozenCols
+          ? table.tableNoFrameWidth
+          : table.tableNoFrameWidth - table.getFrozenColsWidth() - table.getRightFrozenColsWidth();
+        clipHorizontalScrollbar(horizontalLeft, horizontalWidth);
+      }
+
+      if (
+        horizontalVisible !== 'none' &&
+        !ignoreFrozenCols &&
+        table.options?.scrollFrozenCols &&
+        table.getFrozenColsOffset?.() > 0
+      ) {
+        clipHorizontalScrollbar(!hoverOn ? groupX : 0, table.getFrozenColsWidth());
+      }
+
+      if (
+        horizontalVisible !== 'none' &&
+        !ignoreFrozenCols &&
+        table.options?.scrollRightFrozenCols &&
+        table.getRightFrozenColsOffset?.() > 0
+      ) {
+        clipHorizontalScrollbar(
+          table.tableNoFrameWidth - table.getRightFrozenColsWidth() + (!hoverOn ? groupX : 0),
+          table.getRightFrozenColsWidth()
+        );
       }
     }
 

--- a/packages/vue-vtable/src/components/custom/vtable-vue-attribute-plugin.ts
+++ b/packages/vue-vtable/src/components/custom/vtable-vue-attribute-plugin.ts
@@ -489,7 +489,16 @@ export class VTableVueAttributePlugin extends HtmlAttributePlugin implements IPl
     const { vue: options, width, height, visible, display, ...rest } = attribute || {};
     const { x: left, y: top } = this.calculatePosition(graphic, options.anchorType);
     const { left: offsetX, top: offsetTop } = this.calculateOffset(stage, nativeContainer, left, top);
-    const { safeWidth, safeHeight } = this.getScrollbarSafeSize(graphic, offsetX, offsetTop, width, height, options);
+    const { safeWidth, safeHeight } = this.getScrollbarSafeSize(
+      graphic,
+      stage,
+      nativeContainer,
+      offsetX,
+      offsetTop,
+      width,
+      height,
+      options
+    );
 
     const { id } = this.getGraphicOptions(graphic) || {};
     const record = id ? this.htmlMap[id] : null;
@@ -548,6 +557,8 @@ export class VTableVueAttributePlugin extends HtmlAttributePlugin implements IPl
 
   private getScrollbarSafeSize(
     graphic: IGraphic,
+    stage: IStage,
+    nativeContainer: HTMLElement,
     offsetX: number,
     offsetTop: number,
     width: number,
@@ -579,14 +590,21 @@ export class VTableVueAttributePlugin extends HtmlAttributePlugin implements IPl
         const verticalTop = table.getFrozenRowsHeight() + (!hoverOn ? groupY : 0);
         const verticalBottom =
           verticalTop + table.tableNoFrameHeight - table.getFrozenRowsHeight() - table.getBottomFrozenRowsHeight();
+        const { left: verticalDomLeft, top: verticalDomTop } = this.calculateOffset(
+          stage,
+          nativeContainer,
+          verticalLeft,
+          verticalTop
+        );
+        const verticalDomBottom = verticalDomTop + verticalBottom - verticalTop;
 
         if (
-          offsetTop < verticalBottom &&
-          domBottom > verticalTop &&
-          offsetX < verticalLeft + scrollBarSize &&
-          domRight > verticalLeft
+          offsetTop < verticalDomBottom &&
+          domBottom > verticalDomTop &&
+          offsetX < verticalDomLeft + scrollBarSize &&
+          domRight > verticalDomLeft
         ) {
-          safeWidth = Math.max(0, Math.min(width, verticalLeft - offsetX));
+          safeWidth = Math.max(0, Math.min(width, verticalDomLeft - offsetX));
         }
       }
 
@@ -603,14 +621,21 @@ export class VTableVueAttributePlugin extends HtmlAttributePlugin implements IPl
         const horizontalTop =
           Math.min(table.tableNoFrameHeight, table.getAllRowsHeight()) - (hoverOn ? scrollBarSize : -groupY);
         const horizontalRight = horizontalLeft + horizontalWidth;
+        const { left: horizontalDomLeft, top: horizontalDomTop } = this.calculateOffset(
+          stage,
+          nativeContainer,
+          horizontalLeft,
+          horizontalTop
+        );
+        const horizontalDomRight = horizontalDomLeft + horizontalRight - horizontalLeft;
 
         if (
-          offsetX < horizontalRight &&
-          domRight > horizontalLeft &&
-          offsetTop < horizontalTop + scrollBarSize &&
-          domBottom > horizontalTop
+          offsetX < horizontalDomRight &&
+          domRight > horizontalDomLeft &&
+          offsetTop < horizontalDomTop + scrollBarSize &&
+          domBottom > horizontalDomTop
         ) {
-          safeHeight = Math.max(0, Math.min(height, horizontalTop - offsetTop));
+          safeHeight = Math.max(0, Math.min(height, horizontalDomTop - offsetTop));
         }
       }
     }

--- a/packages/vue-vtable/src/components/custom/vtable-vue-attribute-plugin.ts
+++ b/packages/vue-vtable/src/components/custom/vtable-vue-attribute-plugin.ts
@@ -567,11 +567,52 @@ export class VTableVueAttributePlugin extends HtmlAttributePlugin implements IPl
       const hasVerticalScrollBar = verticalVisible !== 'none' && table.getAllRowsHeight() > table.tableNoFrameHeight;
       const hasHorizontalScrollBar = horizontalVisible !== 'none' && table.getAllColsWidth() > table.tableNoFrameWidth;
       const scrollBarSize = scrollStyle?.width ?? 7;
-      const maxRight = table.tableNoFrameWidth - (hasVerticalScrollBar ? scrollBarSize : 0);
-      const maxBottom = table.tableNoFrameHeight - (hasHorizontalScrollBar ? scrollBarSize : 0);
+      const groupX = table.scenegraph?.tableGroup?.attribute?.x ?? 0;
+      const groupY = table.scenegraph?.tableGroup?.attribute?.y ?? 0;
+      const hoverOn = scrollStyle?.hoverOn;
+      const domRight = offsetX + width;
+      const domBottom = offsetTop + height;
 
-      safeWidth = Math.max(0, Math.min(width, maxRight - offsetX));
-      safeHeight = Math.max(0, Math.min(height, maxBottom - offsetTop));
+      if (hasVerticalScrollBar) {
+        const verticalLeft =
+          Math.min(table.tableNoFrameWidth, table.getAllColsWidth()) - (hoverOn ? scrollBarSize : -groupX);
+        const verticalTop = table.getFrozenRowsHeight() + (!hoverOn ? groupY : 0);
+        const verticalBottom =
+          verticalTop + table.tableNoFrameHeight - table.getFrozenRowsHeight() - table.getBottomFrozenRowsHeight();
+
+        if (
+          offsetTop < verticalBottom &&
+          domBottom > verticalTop &&
+          offsetX < verticalLeft + scrollBarSize &&
+          domRight > verticalLeft
+        ) {
+          safeWidth = Math.max(0, Math.min(width, verticalLeft - offsetX));
+        }
+      }
+
+      if (hasHorizontalScrollBar) {
+        const ignoreFrozenCols = scrollStyle?.ignoreFrozenCols ?? false;
+        const horizontalLeft = ignoreFrozenCols
+          ? !hoverOn
+            ? groupX
+            : 0
+          : table.getFrozenColsWidth() + (!hoverOn ? groupX : 0);
+        const horizontalWidth = ignoreFrozenCols
+          ? table.tableNoFrameWidth
+          : table.tableNoFrameWidth - table.getFrozenColsWidth() - table.getRightFrozenColsWidth();
+        const horizontalTop =
+          Math.min(table.tableNoFrameHeight, table.getAllRowsHeight()) - (hoverOn ? scrollBarSize : -groupY);
+        const horizontalRight = horizontalLeft + horizontalWidth;
+
+        if (
+          offsetX < horizontalRight &&
+          domRight > horizontalLeft &&
+          offsetTop < horizontalTop + scrollBarSize &&
+          domBottom > horizontalTop
+        ) {
+          safeHeight = Math.max(0, Math.min(height, horizontalTop - offsetTop));
+        }
+      }
     }
 
     return { safeWidth, safeHeight };

--- a/packages/vue-vtable/src/components/custom/vtable-vue-attribute-plugin.ts
+++ b/packages/vue-vtable/src/components/custom/vtable-vue-attribute-plugin.ts
@@ -576,7 +576,8 @@ export class VTableVueAttributePlugin extends HtmlAttributePlugin implements IPl
       const verticalVisible = scrollStyle?.verticalVisible ?? scrollStyle?.visible;
       const horizontalVisible = scrollStyle?.horizontalVisible ?? scrollStyle?.visible;
       const hasVerticalScrollBar = verticalVisible !== 'none' && table.getAllRowsHeight() > table.tableNoFrameHeight;
-      const hasHorizontalScrollBar = horizontalVisible !== 'none' && table.getAllColsWidth() > table.tableNoFrameWidth;
+      const hasHorizontalScrollBar =
+        horizontalVisible !== 'none' && this.getBodyHorizontalScrollRange(table) > this.getScrollSizeTolerance(table);
       const scrollBarSize = scrollStyle?.width ?? 7;
       const groupX = table.scenegraph?.tableGroup?.attribute?.x ?? 0;
       const groupY = table.scenegraph?.tableGroup?.attribute?.y ?? 0;
@@ -641,6 +642,22 @@ export class VTableVueAttributePlugin extends HtmlAttributePlugin implements IPl
     }
 
     return { safeWidth, safeHeight };
+  }
+
+  private getBodyHorizontalScrollRange(table: any) {
+    const totalWidth = table.getAllColsWidth();
+    const frozenColsWidth = table.getFrozenColsWidth();
+    const rightFrozenColsWidth = table.getRightFrozenColsWidth();
+    const frozenColsContentWidth = table.getFrozenColsContentWidth?.() ?? frozenColsWidth;
+    const rightFrozenColsContentWidth = table.getRightFrozenColsContentWidth?.() ?? rightFrozenColsWidth;
+    const bodyViewportWidth = table.tableNoFrameWidth - frozenColsWidth - rightFrozenColsWidth;
+    const bodyContentWidth = totalWidth - frozenColsContentWidth - rightFrozenColsContentWidth;
+
+    return Math.max(0, bodyContentWidth - bodyViewportWidth);
+  }
+
+  private getScrollSizeTolerance(table: any) {
+    return table.options?.customConfig?._disableColumnAndRowSizeRound ? 1 : 0;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Fix #5157
- Keep Vue custom layout DOM with pointerEvents enabled from covering scrollbar hit areas
- Refresh overlay style even when position is unchanged so pointer/style/visible changes apply
- Add Vue demo Issue5157CustomLayoutScrollbar

## Verification
- packages/vtable-editors: rushx build
- packages/vtable: rushx build
- packages/vue-vtable: rushx compile
- Chrome DevTools MCP: window.issue5157Check() => pass=true