### PR TITLE
fix: align frozen rows in short tables

### DIFF
--- a/common/changes/@visactor/vtable/fix-issue-5253-frozen-row-layout_2026-07-29-17-46.json
+++ b/common/changes/@visactor/vtable/fix-issue-5253-frozen-row-layout_2026-07-29-17-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix: align frozen rows in short tables",
+      "type": "patch",
+      "packageName": "@visactor/vtable"
+    }
+  ],
+  "packageName": "@visactor/vtable",
+  "email": "biukam.w@gmail.com"
+}

--- a/packages/vtable/__tests__/options/listTable-api-with-frozen.test.ts
+++ b/packages/vtable/__tests__/options/listTable-api-with-frozen.test.ts
@@ -143,6 +143,28 @@ describe('listTable init test', () => {
     });
   });
 
+  test('listTable should keep bottom frozen rows next to short table content', () => {
+    const shortTableContainer = createDiv();
+    shortTableContainer.style.position = 'relative';
+    shortTableContainer.style.width = '1000px';
+    shortTableContainer.style.height = '800px';
+
+    const shortTable = new ListTable({
+      ...option,
+      container: shortTableContainer,
+      records: records.slice(0, 6),
+      frozenRowCount: 4,
+      bottomFrozenRowCount: 1
+    });
+    const contentHeight = shortTable.getAllRowsHeight();
+    const bottomFrozenHeight = shortTable.getBottomFrozenRowsHeight();
+
+    expect(shortTable.scenegraph.tableGroup.attribute.height).toBe(contentHeight);
+    expect(shortTable.scenegraph.bottomFrozenGroup.attribute.y).toBe(contentHeight - bottomFrozenHeight);
+
+    shortTable.release();
+  });
+
   test('listTable should support decreasing rightFrozenColCount by setter with row series number', () => {
     const optionWithRightFrozen = {
       ...option,

--- a/packages/vtable/src/scenegraph/scenegraph.ts
+++ b/packages/vtable/src/scenegraph/scenegraph.ts
@@ -1316,25 +1316,7 @@ export class Scenegraph {
         0
       );
 
-    const contentHeight =
-      Math.max(
-        this.colHeaderGroup.attribute.height,
-        this.cornerHeaderGroup.attribute.height,
-        this.rightTopCornerGroup.attribute.height,
-        0
-      ) +
-      Math.max(
-        this.rowHeaderGroup.attribute.height,
-        this.bodyGroup.attribute.height,
-        this.rightFrozenGroup.attribute.height,
-        0
-      ) +
-      Math.max(
-        this.leftBottomCornerGroup.attribute.height,
-        this.bottomFrozenGroup.attribute.height,
-        this.rightBottomCornerGroup.attribute.height,
-        0
-      );
+    const contentHeight = this.table.getAllRowsHeight();
 
     // 处理containerFit模式
     let tableWidth = contentWidth;


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link

fix #5253

### 💡 Background and solution

When table content is shorter than the viewport, combining top and bottom frozen rows can inflate the scenegraph content height and place the bottom frozen row below the actual content.

The body scene container already includes the top frozen-row offset, but `updateTableSize()` added the top, body, and bottom scene-container heights again. This counted the top frozen area twice.

This change uses `getAllRowsHeight()` as the canonical content height, keeping the table group, bottom frozen rows, and scrollbar metrics aligned. A regression test covers six records with four top frozen rows and one bottom frozen row. Before the fix, the table group height was 400 instead of 280; after the fix, the table group height is 280 and the bottom frozen group ends at the same content boundary.

### ✅ Validation

- Frozen-row Jest coverage: 4 suites and 19 tests passed.
- ESLint: 0 errors; 59 existing warnings in `scenegraph.ts`.
- Prettier check and `git diff --check` passed.
- Rush recognized the new patch change record. Its verification command still reports the repository's existing `upstream/main` lookup warning.
- `npm run compile` remains blocked by four pre-existing errors in `src/state/checkbox/checkbox.ts` (TS7006 and TS2339). This pull request does not modify that module.
- The repository-wide pre-push suite is also blocked by existing failures involving the same checkbox type errors, local package resolution in `vtable-sheet`, existing formula assertions, the video-cell test environment, and an existing checkbox record-index assertion. The focused frozen-row suites above pass, and this pull request only changes the scenegraph height calculation, its regression test, and the Rush change record.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix frozen-row layout when table content does not fill the viewport. |
| 🇨🇳 Chinese | 修复数据不足一屏时设置冻结行导致的布局错乱。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
