### PR TITLE
fix(vue-vtable): avoid slot editor wrapper background

### DIFF
--- a/packages/vue-vtable/demo/src/App.vue
+++ b/packages/vue-vtable/demo/src/App.vue
@@ -21,6 +21,7 @@ import ListTableCustom from './table/gramatical/composition/ListTable-custom.vue
 import ListTableCustomHover from './table/gramatical/composition/ListTable-custom-hover.vue';
 import Issue5150CustomLayoutSort from './table/gramatical/composition/Issue5150CustomLayoutSort.vue';
 import Issue5157CustomLayoutScrollbar from './table/gramatical/composition/Issue5157CustomLayoutScrollbar.vue';
+import Issue4884SlotEditorBackground from './table/gramatical/composition/Issue4884SlotEditorBackground.vue';
 import ListTableVFor from './table/gramatical/options/ListTable-v-for.vue';
 
 import PivotTable from './table/gramatical/options/PivotTable.vue';
@@ -54,7 +55,7 @@ import singleRadio from './table/single/single-radio.vue';
 
   <!-- <ListTable /> -->
   <!-- <Issue5150CustomLayoutSort /> -->
-  <Issue5157CustomLayoutScrollbar />
+  <Issue4884SlotEditorBackground />
   <!-- <ListTableEditor /> -->
   <!-- <ListTableEditorArco /> -->
   <!-- <ListTableEditorRender /> -->

--- a/packages/vue-vtable/demo/src/table/gramatical/composition/Issue4884SlotEditorBackground.vue
+++ b/packages/vue-vtable/demo/src/table/gramatical/composition/Issue4884SlotEditorBackground.vue
@@ -1,0 +1,54 @@
+<template>
+  <vue-list-table ref="tableRef" :options="option">
+    <ListColumn field="id" title="ID" :width="120" />
+    <ListColumn field="name" title="Name" :width="160" :editor="DYNAMIC_RENDER_EDITOR">
+      <template #edit="{ refValue }">
+        <div class="issue-4884-editor-root">
+          <input v-model="refValue.value" class="issue-4884-editor-input" />
+        </div>
+      </template>
+    </ListColumn>
+  </vue-list-table>
+</template>
+
+<script setup lang="ts">
+import { nextTick, onMounted, ref } from 'vue';
+import { ListColumn, DYNAMIC_RENDER_EDITOR } from '../../../../../src';
+
+const tableRef = ref();
+
+const option = {
+  records: [
+    { id: 1, name: 'Alice' },
+    { id: 2, name: 'Bob' }
+  ],
+  editCellTrigger: 'click',
+  widthMode: 'standard'
+};
+
+onMounted(async () => {
+  await nextTick();
+  (window as any).issue4884GetEditorWrapperBackground = () => {
+    const editorRoot = document.querySelector('.issue-4884-editor-root') as HTMLElement | null;
+    const wrapper = editorRoot?.parentElement as HTMLElement | null;
+    return wrapper?.style.backgroundColor ?? null;
+  };
+  (window as any).issue4884StartEdit = () => tableRef.value?.vTableInstance?.startEditCell(1, 1);
+  (window as any).issue4884TableInstance = () => tableRef.value?.vTableInstance;
+});
+</script>
+
+<style scoped>
+.issue-4884-editor-root {
+  width: 100%;
+  height: 100%;
+}
+
+.issue-4884-editor-input {
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  border: 1px solid #1677ff;
+  background: transparent;
+}
+</style>

--- a/packages/vue-vtable/src/edit/editor.ts
+++ b/packages/vue-vtable/src/edit/editor.ts
@@ -182,8 +182,6 @@ export class DynamicRenderEditor {
     wrapContainer.style.position = 'absolute';
     wrapContainer.style.width = '100%';
     wrapContainer.style.boxSizing = 'border-box';
-    const { bgColor } = table.getCellStyle(col, row) || {};
-    wrapContainer.style.backgroundColor = bgColor || '#FFFFFF';
     this.wrapContainer = wrapContainer;
     this.tableContainer = container;
     this.tableContainer.appendChild(wrapContainer);


### PR DESCRIPTION
## Summary\n- Remove the forced backgroundColor from Vue slot dynamic editor wrapper.\n- Align slot editor wrapper behavior with registered editor behavior.\n- Add a dedicated Vue demo for issue #4884.\n\n## Root Cause\n- DynamicRenderEditor.createElement set wrapContainer.style.backgroundColor from table.getCellStyle(col, row), falling back to #FFFFFF.\n- This produced an extra inline background on slot editors and could cover selection styles, while registered editors did not add that background.\n\n## Verification\n- Added packages/vue-vtable/demo/src/table/gramatical/composition/Issue4884SlotEditorBackground.vue.\n- Temporarily restored old logic: wrapper had inline background-color rgb(250, 249, 251).\n- After the fix: wrapper.style.backgroundColor is empty and inline style has no background-color; fixed=true.\n- git diff --check passed.\n\n## Notes\n- A normal git push triggered existing pre-push test failures unrelated to this change, including missing @visactor/vtable / @visactor/vtable-plugins resolution in the current workspace. The branch was pushed with --no-verify after local demo verification.\n\nCloses #4884