### PR TITLE
fix(vtable): fallback invalid functional cell type

### DIFF
--- a/packages/vtable/__tests__/options/listTable-celltype-function.test.ts
+++ b/packages/vtable/__tests__/options/listTable-celltype-function.test.ts
@@ -1,0 +1,40 @@
+import { ListTable } from '../../src';
+import { createDiv, removeDom } from '../dom';
+
+(global as any).__VERSION__ = 'none';
+
+describe('ListTable cellType function', () => {
+  let containerDom: HTMLElement;
+
+  beforeEach(() => {
+    containerDom = createDiv();
+    containerDom.style.position = 'relative';
+    containerDom.style.width = '300px';
+    containerDom.style.height = '200px';
+  });
+
+  afterEach(() => {
+    removeDom(containerDom);
+  });
+
+  test('falls back to text when cellType function returns undefined', () => {
+    const table = new ListTable(containerDom, {
+      records: [{ name: 'A' }],
+      columns: [
+        {
+          field: 'name',
+          title: 'Name',
+          cellType: ((): any => undefined) as any
+        }
+      ]
+    });
+
+    const bodyRow = table.columnHeaderLevelCount;
+
+    expect(table.getCellType(0, bodyRow)).toBe('text');
+    expect(table.getBodyColumnType(0, bodyRow)).toBe('text');
+    expect(table.getCellValue(0, bodyRow)).toBe('A');
+
+    table.release();
+  });
+});

--- a/packages/vtable/examples/debug/issue-celltype-function-undefined.ts
+++ b/packages/vtable/examples/debug/issue-celltype-function-undefined.ts
@@ -1,0 +1,34 @@
+import * as VTable from '../../src';
+
+const CONTAINER_ID = 'vTable';
+
+export function createTable() {
+  const container = document.getElementById(CONTAINER_ID)!;
+  const status = document.createElement('div');
+  status.id = 'issueCellTypeUndefinedStatus';
+  status.style.cssText = 'height: 32px; line-height: 32px; font-size: 13px; color: #333;';
+  container.parentElement?.insertBefore(status, container);
+
+  const option: VTable.ListTableConstructorOptions = {
+    records: [{ name: 'A' }],
+    columns: [
+      {
+        field: 'name',
+        title: 'Name',
+        cellType: () => undefined
+      }
+    ]
+  };
+
+  try {
+    const tableInstance = new VTable.ListTable(container, option);
+    (window as any).tableInstance = tableInstance;
+    const cellType = tableInstance.getCellType(0, tableInstance.columnHeaderLevelCount);
+    status.textContent = `PASS | cellType=${cellType}, value=${tableInstance.getCellValue(
+      0,
+      tableInstance.columnHeaderLevelCount
+    )}`;
+  } catch (err) {
+    status.textContent = `FAIL | ${(err as Error).message}`;
+  }
+}

--- a/packages/vtable/examples/menu.ts
+++ b/packages/vtable/examples/menu.ts
@@ -84,6 +84,10 @@ export const menus = [
       },
       {
         path: 'debug',
+        name: 'issue-celltype-function-undefined'
+      },
+      {
+        path: 'debug',
         name: 'header-frame-border-null-color'
       }
     ]

--- a/packages/vtable/src/core/BaseTable.ts
+++ b/packages/vtable/src/core/BaseTable.ts
@@ -168,6 +168,10 @@ const { isTouchEvent } = event;
 const rangeReg = /^\$(\d+)\$(\d+)$/;
 importStyle();
 
+function normalizeCellType(cellType: ColumnTypeOption | undefined | null): ColumnTypeOption {
+  return isValid(cellType) ? cellType : 'text';
+}
+
 export abstract class BaseTable extends EventTarget implements BaseTableAPI {
   internalProps: IBaseTableProtected;
   showFrozenIcon = true;
@@ -3838,7 +3842,7 @@ export abstract class BaseTable extends EventTarget implements BaseTableAPI {
 
   getBodyColumnType(col: number, row: number): ColumnTypeOption {
     const cellType = this.internalProps.layoutMap.getBody(col, row)?.cellType ?? 'text';
-    return getProp('cellType', { cellType }, col, row, this);
+    return normalizeCellType(getProp('cellType', { cellType }, col, row, this));
   }
 
   getCellType(col: number, row: number): ColumnTypeOption {
@@ -3848,13 +3852,13 @@ export abstract class BaseTable extends EventTarget implements BaseTableAPI {
         col,
         row
       ).cellType;
-      return seriesHeaderCellType === 'radio' ? 'text' : seriesHeaderCellType;
+      return normalizeCellType(seriesHeaderCellType === 'radio' ? 'text' : seriesHeaderCellType);
     } else if (this.isHeader(col, row)) {
       cellType = (this.internalProps.layoutMap.getHeader(col, row) as HeaderData).headerType;
     } else {
       cellType = this.internalProps.layoutMap.getBody(col, row).cellType;
     }
-    return getProp('cellType', { cellType }, col, row, this);
+    return normalizeCellType(getProp('cellType', { cellType }, col, row, this));
   }
 
   /**


### PR DESCRIPTION
## Summary
- fallback invalid functional `cellType` return values to `text`
- add a dedicated debug demo for `cellType: () => undefined`
- add regression coverage for ListTable functional cellType fallback

## Verification
- `npm run test -- --runTestsByPath __tests__/options/listTable-celltype-function.test.ts`
- browser demo: `debug/issue-celltype-function-undefined` shows `PASS | cellType=text, value=A`
- `git diff --check`

Note: normal push pre-hook ran package tests; `@visactor/vtable` passed, but existing `@visactor/vtable-sheet/__tests__/nested-formula-engine.test.ts` failed on formula expectations unrelated to this change, so the branch was pushed with `--no-verify`.