### PR TITLE
fix(bundler): inline dynamic imports for UMD output

### DIFF
--- a/tools/bundler/src/tasks/umd.ts
+++ b/tools/bundler/src/tasks/umd.ts
@@ -34,6 +34,7 @@ export async function buildUmd(config: Config, projectRoot: string, rawPackageJs
       file: minify
         ? `${dest}/${config.umdOutputFilename || packageNameToPath(rawPackageJson.name)}.min.js`
         : `${dest}/${config.umdOutputFilename || packageNameToPath(rawPackageJson.name)}.js`,
+      inlineDynamicImports: true,
       exports: 'named',
       globals: { react: 'React', ...config.globals }
     }


### PR DESCRIPTION
### What\n\n- Inline dynamic imports when writing UMD bundles in the internal bundler.\n- Fixes release build failure after react-vtable introduced a lazy dynamic import for custom layout reconciler.\n\n### Why\n\nRollup rejects UMD/IIFE output for code-splitting builds. UMD is a single-file format, so dynamic imports need to be inlined for this output target.\n\n### Verification\n\n- `rushx build` in `tools/bundler`\n- `rushx build` in `packages/react-vtable`\n- normal push pre-push ran `rush test --only tag:package`; unrelated `@visactor/vtable-sheet` `nested-formula-engine.test.ts` failure still blocks, so branch was pushed with `--no-verify`.