### PR TITLE
fix: render vue components in top frozen rows

### DIFF
--- a/common/changes/@visactor/vtable/fix-issue-5265-vue-frozen-row-dom_2026-08-04-14-53.json
+++ b/common/changes/@visactor/vtable/fix-issue-5265-vue-frozen-row-dom_2026-08-04-14-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix: render vue components in top frozen rows",
+      "type": "none",
+      "packageName": "@visactor/vtable"
+    }
+  ],
+  "packageName": "@visactor/vtable",
+  "email": "biukam.w@gmail.com"
+}

--- a/packages/vue-vtable/__tests__/vue-stable-id.test.ts
+++ b/packages/vue-vtable/__tests__/vue-stable-id.test.ts
@@ -28,6 +28,8 @@ jest.mock('@visactor/vtable', () => {
     addEventListener() {}
   }
   return {
+    CUSTOM_CONTAINER_NAME: 'custom-container',
+    CUSTOM_MERGE_PRE_NAME: '_custom_',
     CustomLayout: {
       Group: MockGroup,
       Image: MockGroup,
@@ -42,7 +44,8 @@ jest.mock('@visactor/vtable', () => {
 // Mock vue 的 isVNode / cloneVNode
 jest.mock('vue', () => ({
   isVNode: (val: any) => val && val.__v_isVNode === true,
-  cloneVNode: (vnode: any, extra: any) => ({ ...vnode, ...extra })
+  cloneVNode: (vnode: any, extra: any) => ({ ...vnode, ...extra }),
+  render: jest.fn()
 }));
 
 function makeGroupChild(vueProps: any = {}, typeName = 'Group') {
@@ -233,5 +236,70 @@ describe('VTableVueAttributePlugin 缓存命中同步渲染', () => {
     // 无缓存 → 加入异步队列并调用 scheduleRender
     expect(plugin.renderQueue.size).toBe(1);
     expect(plugin.scheduleRender).toHaveBeenCalled();
+  });
+});
+
+describe('VTableVueAttributePlugin 顶部冻结行容器', () => {
+  test.each([
+    ['普通列', 1, 'headerDomContainer'],
+    ['左冻结列', 0, 'frozenHeaderDomContainer'],
+    ['右冻结列', 3, 'rightFrozenHeaderDomContainer']
+  ])('顶部冻结行的%s应挂载到顶部冻结容器', (_name, col, expectedContainerKey) => {
+    const { VTableVueAttributePlugin } = jest.requireActual('../src/components/custom/vtable-vue-attribute-plugin');
+    const plugin = new VTableVueAttributePlugin();
+    plugin.htmlMap = {};
+    plugin.renderId = 1;
+
+    const table = {
+      bodyDomContainer: document.createElement('div'),
+      headerDomContainer: document.createElement('div'),
+      frozenBodyDomContainer: document.createElement('div'),
+      frozenHeaderDomContainer: document.createElement('div'),
+      rightFrozenBodyDomContainer: document.createElement('div'),
+      rightFrozenHeaderDomContainer: document.createElement('div'),
+      bottomFrozenBodyDomContainer: document.createElement('div'),
+      rightFrozenBottomDomContainer: document.createElement('div'),
+      frozenColCount: 1,
+      rightFrozenColCount: 1,
+      frozenRowCount: 2,
+      bottomFrozenRowCount: 0,
+      colCount: 4,
+      rowCount: 10,
+      options: {}
+    };
+    const stage = {
+      table,
+      window: { getContainer: () => document.body }
+    };
+    const targetGroup = {
+      name: 'custom-container',
+      col,
+      row: 1,
+      stage,
+      parent: {}
+    };
+    const graphic = {
+      attribute: {
+        vue: {
+          id: `top-frozen-${col}`,
+          element: { __v_isVNode: true },
+          container: table.bodyDomContainer
+        }
+      },
+      stage,
+      parent: targetGroup
+    };
+    const wrapContainer = document.createElement('div');
+    plugin.getWrapContainer = jest.fn((_stage, container) => ({
+      wrapContainer,
+      nativeContainer: container
+    }));
+    plugin.updateStyleOfWrapContainer = jest.fn();
+
+    plugin.doRenderGraphic(graphic);
+
+    const actualContainer = plugin.getWrapContainer.mock.calls[0][1];
+    expect(actualContainer).toBe(table[expectedContainerKey]);
+    expect(actualContainer).not.toBe(table.bodyDomContainer);
   });
 });

--- a/packages/vue-vtable/src/components/custom/vtable-vue-attribute-plugin.ts
+++ b/packages/vue-vtable/src/components/custom/vtable-vue-attribute-plugin.ts
@@ -842,6 +842,12 @@ function checkFrozenContainer(graphic: IGraphic) {
       container = table.rightFrozenBottomDomContainer;
     } else if (row >= table.rowCount - table.bottomFrozenRowCount) {
       container = table.bottomFrozenBodyDomContainer;
+    } else if (row < table.frozenRowCount && col < table.frozenColCount) {
+      container = table.frozenHeaderDomContainer;
+    } else if (row < table.frozenRowCount && col >= table.colCount - table.rightFrozenColCount) {
+      container = table.rightFrozenHeaderDomContainer;
+    } else if (row < table.frozenRowCount) {
+      container = table.headerDomContainer;
     } else if (col < table.frozenColCount) {
       container = table.frozenBodyDomContainer;
     } else if (col >= table.colCount - table.rightFrozenColCount) {


### PR DESCRIPTION
### 🤔 这个分支是...

- [x] Bug fix
- [x] 测试 case 更新

### 🔗 相关 issue 连接

close #5265

### 💡 问题的背景&解决方案

顶部冻结数据行位于顶部冻结区域，但 Vue DOM 自定义布局此前仍使用 body 容器，导致组件挂载到错误的覆盖层并显示为空白。

本次修改补充了顶部冻结行的容器路由：

- 普通列使用 `headerDomContainer`
- 左冻结列使用 `frozenHeaderDomContainer`
- 右冻结列使用 `rightFrozenHeaderDomContainer`

底部冻结行的现有判断优先级保持不变，并新增三个回归场景覆盖上述容器映射。

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Render Vue DOM components correctly in top frozen rows. |
| 🇨🇳 Chinese | 修复顶部冻结行中的 Vue DOM 组件无法正常显示的问题。 |

### ☑️ 自测

- [x] 文档不需要更新
- [x] Demo 不需要更新
- [x] Ts 类型定义不需要更新
- [x] Changelog 已提供

验证结果：

- `npm test -- --runInBand vue-stable-id.test.ts`：11/11 通过
- `npm run compile`：通过
- `rush build -t @visactor/vue-vtable`：通过，存在仓库既有构建 warning
- `rush change --verify --target-branch upstream/develop --no-fetch`：通过
- ESLint：0 error，25 个既有 warning
- Prettier：通过

正常 push 触发的全量 pre-push 测试中，`vue-vtable` 11/11、`vtable` 274/274、`vtable-plugins` 64/64、`vtable-gantt` 25/25 均通过。未改动的 `vtable-sheet` 包存在既有失败，主要为 `@visactor/vtable-plugins` / `@visactor/vtable-gantt` 模块解析问题，另有两个公式错误处理断言差异；本次差异不涉及该包。
