### PR TITLE
fix: prevent React plugin render loop

### DIFF
--- a/common/changes/@visactor/react-vtable/fix-issue-4859-react-plugins-loop_2026-08-05-16-50.json
+++ b/common/changes/@visactor/react-vtable/fix-issue-4859-react-plugins-loop_2026-08-05-16-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@visactor/react-vtable",
+      "comment": "fix: prevent plugin options from causing a React render loop (GitHub #4859)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@visactor/react-vtable",
+  "email": "biukam.w@gmail.com"
+}

--- a/packages/react-vtable/__tests__/list-table-plugins.test.tsx
+++ b/packages/react-vtable/__tests__/list-table-plugins.test.tsx
@@ -1,0 +1,54 @@
+/* eslint-env jest, browser */
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+import type { Root } from 'react-dom/client';
+import { FilterPlugin } from '../../vtable-plugins/src/filter';
+import { ListColumn, ListTable } from '../src';
+
+describe('ListTable plugins', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let consoleError: jest.SpyInstance;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    container.style.width = '800px';
+    container.style.height = '400px';
+    document.body.appendChild(container);
+    root = createRoot(container);
+    consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    consoleError.mockRestore();
+  });
+
+  test('does not enter an update loop when a filter plugin is configured', async () => {
+    const onReady = jest.fn();
+
+    await act(async () => {
+      root.render(
+        <ListTable
+          records={[
+            { name: 'Alice', age: 28 },
+            { name: 'Bob', age: 31 }
+          ]}
+          plugins={[new FilterPlugin({})]}
+          onReady={onReady}
+        >
+          <ListColumn field="name" title="Name" />
+          <ListColumn field="age" title="Age" />
+        </ListTable>
+      );
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+
+    expect(onReady).toHaveBeenCalledTimes(1);
+    expect(consoleError.mock.calls.some(args => String(args[0]).includes('Maximum update depth exceeded'))).toBe(false);
+  });
+});

--- a/packages/react-vtable/__tests__/list-table-plugins.test.tsx
+++ b/packages/react-vtable/__tests__/list-table-plugins.test.tsx
@@ -9,7 +9,6 @@ import { ListColumn, ListTable } from '../src';
 describe('ListTable plugins', () => {
   let container: HTMLDivElement;
   let root: Root;
-  let consoleError: jest.SpyInstance;
 
   beforeEach(() => {
     container = document.createElement('div');
@@ -17,7 +16,6 @@ describe('ListTable plugins', () => {
     container.style.height = '400px';
     document.body.appendChild(container);
     root = createRoot(container);
-    consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
   });
 
   afterEach(() => {
@@ -25,11 +23,15 @@ describe('ListTable plugins', () => {
       root.unmount();
     });
     container.remove();
-    consoleError.mockRestore();
   });
 
   test('does not enter an update loop when a filter plugin is configured', async () => {
+    let readyResolve!: () => void;
+    const ready = new Promise<void>(resolve => {
+      readyResolve = resolve;
+    });
     const onReady = jest.fn();
+    onReady.mockImplementationOnce(() => readyResolve());
 
     await act(async () => {
       root.render(
@@ -45,10 +47,9 @@ describe('ListTable plugins', () => {
           <ListColumn field="age" title="Age" />
         </ListTable>
       );
-      await new Promise(resolve => setTimeout(resolve, 50));
     });
+    await ready;
 
     expect(onReady).toHaveBeenCalledTimes(1);
-    expect(consoleError.mock.calls.some(args => String(args[0]).includes('Maximum update depth exceeded'))).toBe(false);
   });
 });

--- a/packages/react-vtable/jest.config.js
+++ b/packages/react-vtable/jest.config.js
@@ -29,12 +29,26 @@ module.exports = {
   },
   cacheDirectory: '<rootDir>/.jest-cache',
   moduleNameMapper: {
-    'd3-color': path.resolve(__dirname, '../vtable/node_modules/d3-color/dist/d3-color.min.js'),
-    'd3-array': path.resolve(__dirname, '../vtable/node_modules/d3-array/dist/d3-array.min.js'),
-    'd3-geo': path.resolve(__dirname, '../vtable/node_modules/d3-geo/dist/d3-geo.min.js'),
-    'd3-dsv': path.resolve(__dirname, '../vtable/node_modules/d3-dsv/dist/d3-dsv.min.js'),
-    'd3-hexbin': path.resolve(__dirname, '../vtable/node_modules/d3-hexbin/build/d3-hexbin.min.js'),
-    'd3-hierarchy': path.resolve(__dirname, '../vtable/node_modules/d3-hierarchy/dist/d3-hierarchy.min.js'),
+    'd3-array': path.resolve(
+      __dirname,
+      '../../common/temp/node_modules/.pnpm/d3-array@3.2.3/node_modules/d3-array/dist/d3-array.min.js'
+    ),
+    'd3-geo': path.resolve(
+      __dirname,
+      '../../common/temp/node_modules/.pnpm/d3-geo@3.1.1/node_modules/d3-geo/dist/d3-geo.min.js'
+    ),
+    'd3-dsv': path.resolve(
+      __dirname,
+      '../../common/temp/node_modules/.pnpm/d3-dsv@3.0.1/node_modules/d3-dsv/dist/d3-dsv.min.js'
+    ),
+    'd3-hexbin': path.resolve(
+      __dirname,
+      '../../common/temp/node_modules/.pnpm/d3-hexbin@0.2.2/node_modules/d3-hexbin/build/d3-hexbin.min.js'
+    ),
+    'd3-hierarchy': path.resolve(
+      __dirname,
+      '../../common/temp/node_modules/.pnpm/d3-hierarchy@3.1.2/node_modules/d3-hierarchy/dist/d3-hierarchy.min.js'
+    ),
     ...createVRenderModuleNameMapper('<rootDir>/../vtable/node_modules'),
     '@visactor/vtable$': '<rootDir>/../vtable/src/index',
     '@visactor/vtable/es/(.*)': '<rootDir>/../vtable/src/$1',

--- a/packages/react-vtable/jest.config.js
+++ b/packages/react-vtable/jest.config.js
@@ -1,0 +1,45 @@
+const path = require('path');
+const { createVRenderModuleNameMapper } = require('../../common/config/jest/vrender-module-name-mapper');
+
+module.exports = {
+  preset: 'ts-jest',
+  runner: 'jest-electron/runner',
+  testEnvironment: 'jest-electron/environment',
+  testRegex: '/__tests__(/.*)+\\.test\\.(js|ts|tsx)$',
+  silent: false,
+  verbose: true,
+  globals: {
+    'ts-jest': {
+      diagnostics: false,
+      isolatedModules: true,
+      tsconfig: {
+        resolveJsonModule: true,
+        esModuleInterop: true,
+        jsx: 'react',
+        baseUrl: '.',
+        paths: {
+          '@visactor/vtable': ['../vtable/src/index'],
+          '@visactor/vtable/*': ['../vtable/src/*'],
+          '@src/*': ['../vtable/src/*'],
+          '@vutils-extension': ['../vtable/src/vutil-extension-temp/index']
+        }
+      }
+    },
+    __DEV__: true
+  },
+  cacheDirectory: '<rootDir>/.jest-cache',
+  moduleNameMapper: {
+    'd3-color': path.resolve(__dirname, '../vtable/node_modules/d3-color/dist/d3-color.min.js'),
+    'd3-array': path.resolve(__dirname, '../vtable/node_modules/d3-array/dist/d3-array.min.js'),
+    'd3-geo': path.resolve(__dirname, '../vtable/node_modules/d3-geo/dist/d3-geo.min.js'),
+    'd3-dsv': path.resolve(__dirname, '../vtable/node_modules/d3-dsv/dist/d3-dsv.min.js'),
+    'd3-hexbin': path.resolve(__dirname, '../vtable/node_modules/d3-hexbin/build/d3-hexbin.min.js'),
+    'd3-hierarchy': path.resolve(__dirname, '../vtable/node_modules/d3-hierarchy/dist/d3-hierarchy.min.js'),
+    ...createVRenderModuleNameMapper('<rootDir>/../vtable/node_modules'),
+    '@visactor/vtable$': '<rootDir>/../vtable/src/index',
+    '@visactor/vtable/es/(.*)': '<rootDir>/../vtable/src/$1',
+    '@src/(.*)': '<rootDir>/../vtable/src/$1',
+    '@vutils-extension': '<rootDir>/../vtable/src/vutil-extension-temp/index'
+  },
+  setupFiles: ['./setup-mock.js']
+};

--- a/packages/react-vtable/package.json
+++ b/packages/react-vtable/package.json
@@ -41,6 +41,7 @@
     "start:react19": "npm run setup:react19-deps && vite --config ./demo/vite.config.react19.ts ./demo",
     "build": "npm run fix-memory-limit && bundle --clean",
     "compile": "tsc --noEmit",
+    "test": "jest --config jest.config.js",
     "eslint": "eslint --debug --fix src/",
     "fix-memory-limit": "cross-env LIMIT=10240 increase-memory-limit"
   },

--- a/packages/react-vtable/src/tables/base-table.tsx
+++ b/packages/react-vtable/src/tables/base-table.tsx
@@ -139,6 +139,8 @@ const BaseTable: React.FC<Props> = React.forwardRef((props, ref) => {
   const optionFromChildren = useRef<Omit<IOption, 'records'>>(null);
   const prevRecords = useRef(props.records);
   const eventsBinded = React.useRef<BaseTableProps>(null);
+  const latestProps = useRef(props);
+  const isInitialReady = useRef(true);
   const skipFunctionDiff = !!props.skipFunctionDiff;
   const keepColumnWidthChange = !!props.keepColumnWidthChange;
   const columnWidths = useRef<Map<string, number>>(new Map());
@@ -148,6 +150,7 @@ const BaseTable: React.FC<Props> = React.forwardRef((props, ref) => {
   if (tableContext.current) {
     tableContext.current.onError = props.onError;
   }
+  latestProps.current = props;
 
   const parseOption = useCallback(
     (props: Props) => {
@@ -235,17 +238,17 @@ const BaseTable: React.FC<Props> = React.forwardRef((props, ref) => {
       if (!tableContext.current || !tableContext.current.table) {
         return;
       }
+      const currentProps = latestProps.current;
       // rebind events after render
-      bindEventsToTable(tableContext.current.table, props, eventsBinded.current, TABLE_EVENTS);
+      bindEventsToTable(tableContext.current.table, currentProps, eventsBinded.current, TABLE_EVENTS);
 
-      // to be fixed
-      // will cause another useEffect
-      setUpdateId(updateId + 1);
-      if (props.onReady) {
-        props.onReady(tableContext.current.table, updateId === 0);
+      setUpdateId(currentUpdateId => currentUpdateId + 1);
+      if (currentProps.onReady) {
+        currentProps.onReady(tableContext.current.table, isInitialReady.current);
       }
+      isInitialReady.current = false;
     }
-  }, [updateId, setUpdateId, props]);
+  }, []);
 
   const renderTable = useCallback(() => {
     if (tableContext.current.table) {

--- a/packages/react-vtable/tscofig.eslint.json
+++ b/packages/react-vtable/tscofig.eslint.json
@@ -15,6 +15,7 @@
   },
   "include": [
     "src",
-    "demo"
+    "demo",
+    "__tests__"
   ]
 }


### PR DESCRIPTION
<!--
首先，感谢您参与代码贡献! 😄
为了提交新的功能或修改,请在主分支`main`分支上拉取开发分支 。
在提交PR 之前，请确认下面列到的一些内容
你的PR在核心成员review后，合并到主分支
谢谢！
-->

### 🤔 这个分支是...

- [ ] 新功能
- [x] Bug fix
- [ ] Ts 类型更新
- [ ] 打包优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 重构
- [ ] 依赖版本更新
- [ ] 代码优化
- [ ] 测试 case 更新
- [ ] 分支合并
- [ ] 网站/文档更新
- [ ] demo 更新
- [ ] Workflow
- [ ] 配置修改
- [ ] 发布
- [ ] 其他 (具体是什么，请补充?)

### 🔗 相关 issue 连接

fix #4859

### 💡 问题的背景&解决方案

React `ListTable` 配置 `plugins={[new FilterPlugin({})]}` 后，内部表格渲染会更新 `updateId`。原有 `handleTableRender` 同时依赖 `updateId` 和整个 `props`，回调身份变化会再次触发 option effect。插件实例参与差异比较后，内部刷新会被持续识别为配置更新，最终触发 React `Maximum update depth exceeded`。

本次修改：

- 将 `handleTableRender` 改为稳定回调，并通过 ref 获取最新 props。
- 使用函数式 `setUpdateId`，避免内部计数器成为回调依赖。
- 使用 ref 保留 `onReady(instance, isInitial)` 的首次渲染语义。
- 添加配置 `FilterPlugin` 的 React 回归测试。

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Prevent React ListTable plugin options from causing an infinite render loop. |
| 🇨🇳 Chinese | 修复 React ListTable 配置插件后可能触发的无限渲染循环。 |

### ✅ 验证

- 修复前，回归用例因持续更新超过一分钟无法结束；修复后，1 个测试套件、1 个测试通过。
- React 包 TypeScript 编译与 Rush 目标构建通过。
- pre-push 中 `react-vtable`、`vtable`、`vtable-plugins`、`vtable-gantt`、`vue-vtable` 测试通过。
- 未修改的 `vtable-sheet` 仍存在缺失包构建产物及既有公式断言失败，本分支不包含 `packages/vtable-sheet` 改动。

### ☑️ 自测

⚠️ 在提交 PR 之前，请检查一下内容. ⚠️

- [x] 文档提供了，或者更新，或者不需要
- [x] Demo 提供了，或者更新，或者不需要
- [x] Ts 类型定义提供了，或者更新，或者不需要
- [x] Changelog 提供了，或者不需要

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough