### PR TITLE
fix(vtable-editors): avoid list editor HTML injection

### DIFF
--- a/packages/vtable-editors/__tests__/list-editor.test.ts
+++ b/packages/vtable-editors/__tests__/list-editor.test.ts
@@ -1,0 +1,48 @@
+import { ListEditor } from '../src/list-editor';
+
+describe('ListEditor', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('treats configured option values as text instead of HTML', () => {
+    const values = [
+      '</option></select><img id="xss-image" src=x onerror=alert(1)>',
+      'x" onclick="alert(1)',
+      '<svg id="xss-svg" onload=alert(1)>'
+    ];
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    const editor = new ListEditor({ values });
+    editor.onStart({
+      container,
+      value: values[1],
+      referencePosition: {
+        rect: {
+          left: 0,
+          top: 0,
+          width: 100,
+          height: 24
+        }
+      },
+      endEdit: () => undefined,
+      table: {},
+      col: 0,
+      row: 0
+    });
+
+    const select = container.querySelector('select');
+    expect(select).not.toBeNull();
+    if (!select) {
+      throw new Error('ListEditor did not create a select element');
+    }
+    expect(container.querySelector('img#xss-image')).toBeNull();
+    expect(container.querySelector('svg#xss-svg')).toBeNull();
+    expect(container.querySelectorAll('select')).toHaveLength(1);
+    expect(select.options).toHaveLength(values.length);
+    expect(Array.from(select.options).map(option => option.textContent)).toEqual(values);
+    expect(Array.from(select.options).map(option => option.value)).toEqual(values);
+    expect(select.value).toBe(values[1]);
+  });
+});

--- a/packages/vtable-editors/jest.config.js
+++ b/packages/vtable-editors/jest.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  testRegex: '/__tests__(/.*)+\\.test\\.(js|ts)$',
+  silent: false,
+  verbose: true,
+  globals: {
+    'ts-jest': {
+      diagnostics: {
+        exclude: ['**']
+      },
+      tsconfig: './tsconfig.test.json'
+    },
+    __DEV__: true
+  },
+  cacheDirectory: '<rootDir>/.jest-cache'
+};

--- a/packages/vtable-editors/package.json
+++ b/packages/vtable-editors/package.json
@@ -28,6 +28,7 @@
     "eslint": "eslint --debug --fix src/",
     "build": "npm run fix-memory-limit && bundle",
     "dev": "bundle --clean -f es -w",
+    "test": "jest --silent",
     "test-cov": "jest -w 16 --coverage",
     "test-live": "npm run test-watch __tests__/unit/",
     "test-watch": "DEBUG_MODE=1 jest --watch",

--- a/packages/vtable-editors/src/list-editor.ts
+++ b/packages/vtable-editors/src/list-editor.ts
@@ -41,14 +41,13 @@ export class ListEditor implements IEditor {
 
     // create option tags
     const { values } = this.editorConfig;
-    let opsStr = '';
     values.forEach(item => {
-      opsStr +=
-        item === value
-          ? `<option value="${item}" selected>${item}</option>`
-          : `<option value="${item}" >${item}</option>`;
+      const option = document.createElement('option');
+      option.value = item;
+      option.textContent = item;
+      option.selected = item === value;
+      select.appendChild(option);
     });
-    select.innerHTML = opsStr;
 
     this.container.appendChild(select);
     // this._bindSelectChangeEvent();

--- a/packages/vtable-editors/tsconfig.test.json
+++ b/packages/vtable-editors/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@internal/ts-config/tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["jest", "offscreencanvas", "node"],
+    "lib": ["DOM", "ESNext"],
+    "baseUrl": "./",
+    "rootDir": ".",
+    "paths": {}
+  },
+  "include": ["src", "__tests__"]
+}


### PR DESCRIPTION
## Summary
- Build list editor options with DOM APIs instead of assigning user-controlled values through `innerHTML`
- Preserve option values, labels, and selected state while avoiding HTML parsing

## Test plan
- [x] Ran `git diff --check`
- [ ] `npm run compile` in `packages/vtable-editors` was not runnable in this environment because `tsc` is unavailable

🤖 Generated with Claude Code