### PR TITLE
fix(vtable): align frame border with short frozen rows

### DIFF
--- a/packages/vtable/__tests__/options/listTable-api-with-frozen.test.ts
+++ b/packages/vtable/__tests__/options/listTable-api-with-frozen.test.ts
@@ -305,6 +305,41 @@ describe('listTable init test', () => {
     frozenTable.release();
   });
 
+  test('listTable frame border should match short content with frozen rows', () => {
+    const optionWithShortFrozenRows = {
+      ...option,
+      columns: columns.slice(0, 5).map(column => ({
+        ...column,
+        width: 180
+      })),
+      frozenColCount: 0,
+      rightFrozenColCount: 0,
+      frozenRowCount: 3,
+      bottomFrozenRowCount: 1,
+      container: createDiv(),
+      records: records.slice(0, 6),
+      widthMode: 'standard',
+      theme: {
+        frameStyle: {
+          borderLineWidth: [1, 1, 1, 1],
+          borderColor: 'red'
+        }
+      }
+    };
+    optionWithShortFrozenRows.container.style.position = 'relative';
+    optionWithShortFrozenRows.container.style.width = '900px';
+    optionWithShortFrozenRows.container.style.height = '500px';
+
+    const frozenTable = new ListTable(optionWithShortFrozenRows);
+    const { scenegraph } = frozenTable;
+    const contentBottom = scenegraph.bottomFrozenGroup.attribute.y + scenegraph.bottomFrozenGroup.attribute.height;
+
+    expect(scenegraph.tableGroup.attribute.height).toBe(contentBottom);
+    expect(scenegraph.tableGroup.border.attribute.height).toBe(contentBottom + 1);
+
+    frozenTable.release();
+  });
+
   test('listTable should support decreasing rightFrozenColCount by setter with row series number', () => {
     const optionWithRightFrozen = {
       ...option,

--- a/packages/vtable/examples/debug/issue-5277-frozen-row-border.ts
+++ b/packages/vtable/examples/debug/issue-5277-frozen-row-border.ts
@@ -1,0 +1,47 @@
+import * as VTable from '../../src';
+
+const CONTAINER_ID = 'vTable';
+
+const generateRecords = (count: number) =>
+  Array.from({ length: count }, (_, index) => ({
+    id: index + 1,
+    name: `Name ${index + 1}`,
+    city: ['Beijing', 'Shanghai', 'Shenzhen', 'Hangzhou', 'Chengdu', 'Wuhan'][index % 6],
+    sales: 1000 + index * 100,
+    profit: 120 + index * 10
+  }));
+
+export function createTable() {
+  const container = document.getElementById(CONTAINER_ID);
+  if (!container) {
+    return;
+  }
+  container.style.width = '900px';
+  container.style.height = '500px';
+
+  const columns: VTable.ColumnsDefine = [
+    { field: 'id', title: 'ID', width: 120 },
+    { field: 'name', title: 'Name', width: 180 },
+    { field: 'city', title: 'City', width: 180 },
+    { field: 'sales', title: 'Sales', width: 180 },
+    { field: 'profit', title: 'Profit', width: 180 }
+  ];
+
+  const option: VTable.ListTableConstructorOptions = {
+    container,
+    records: generateRecords(6),
+    frozenRowCount: 3,
+    bottomFrozenRowCount: 1,
+    columns,
+    widthMode: 'standard',
+    theme: {
+      frameStyle: {
+        borderLineWidth: [1, 1, 1, 1],
+        borderColor: 'red'
+      }
+    }
+  };
+
+  const tableInstance = new VTable.ListTable(option);
+  window.tableInstance = tableInstance;
+}

--- a/packages/vtable/examples/menu.ts
+++ b/packages/vtable/examples/menu.ts
@@ -64,6 +64,10 @@ export const menus = [
       },
       {
         path: 'debug',
+        name: 'issue-5277-frozen-row-border'
+      },
+      {
+        path: 'debug',
         name: 'issue-4761-update-records-edit-render'
       },
       {

--- a/packages/vtable/src/scenegraph/scenegraph.ts
+++ b/packages/vtable/src/scenegraph/scenegraph.ts
@@ -1363,78 +1363,6 @@ export class Scenegraph {
       height: tableHeight
     } as any);
 
-    if (this.tableGroup.border) {
-      const rectAttributes = this.tableGroup.border?.attribute;
-      let borderTop;
-      let borderRight;
-      let borderBottom;
-      let borderLeft;
-      if ((rectAttributes as any)?.strokeArrayWidth) {
-        borderTop = (rectAttributes as any).strokeArrayWidth
-          ? (rectAttributes as any).strokeArrayWidth[0]
-          : (rectAttributes.lineWidth as number) ?? 0;
-        borderRight = (rectAttributes as any).strokeArrayWidth
-          ? (rectAttributes as any).strokeArrayWidth[1]
-          : (rectAttributes.lineWidth as number) ?? 0;
-        borderBottom = (rectAttributes as any).strokeArrayWidth
-          ? (rectAttributes as any).strokeArrayWidth[2]
-          : (rectAttributes.lineWidth as number) ?? 0;
-        borderLeft = (rectAttributes as any).strokeArrayWidth
-          ? (rectAttributes as any).strokeArrayWidth[3]
-          : (rectAttributes.lineWidth as number) ?? 0;
-      } else {
-        borderTop = (rectAttributes?.lineWidth as number) ?? 0;
-        borderRight = (rectAttributes?.lineWidth as number) ?? 0;
-        borderBottom = (rectAttributes?.lineWidth as number) ?? 0;
-        borderLeft = (rectAttributes?.lineWidth as number) ?? 0;
-      }
-      if (this.tableGroup.border.type === 'rect') {
-        if (this.table.theme.frameStyle?.innerBorder) {
-          this.tableGroup.border.setAttributes({
-            x: this.table.tableX + borderLeft / 2,
-            y: this.table.tableY + borderTop / 2,
-            width: this.tableGroup.attribute.width - borderLeft / 2 - borderRight / 2,
-            height: this.tableGroup.attribute.height - borderTop / 2 - borderBottom / 2
-          });
-        } else {
-          this.tableGroup.border.setAttributes({
-            x: this.table.tableX - borderLeft / 2,
-            y: this.table.tableY - borderTop / 2,
-            width: this.tableGroup.attribute.width + borderLeft / 2 + borderRight / 2,
-            height: this.tableGroup.attribute.height + borderTop / 2 + borderBottom / 2
-          });
-        }
-      } else if (this.tableGroup.border.type === 'group') {
-        if (this.table.theme.frameStyle?.innerBorder) {
-          this.tableGroup.border.setAttributes({
-            x: this.table.tableX + borderLeft / 2,
-            y: this.table.tableY + borderTop / 2,
-            width: this.tableGroup.attribute.width - borderLeft / 2 - borderRight / 2,
-            height: this.tableGroup.attribute.height - borderTop / 2 - borderBottom / 2
-          });
-          (this.tableGroup.border.firstChild as IRect)?.setAttributes({
-            x: 0,
-            y: 0,
-            width: this.tableGroup.attribute.width - borderLeft / 2 - borderRight / 2,
-            height: this.tableGroup.attribute.height - borderTop / 2 - borderBottom / 2
-          });
-        } else {
-          this.tableGroup.border.setAttributes({
-            x: this.table.tableX - borderLeft / 2,
-            y: this.table.tableY - borderTop / 2,
-            width: this.tableGroup.attribute.width + borderLeft / 2 + borderRight / 2,
-            height: this.tableGroup.attribute.height + borderTop / 2 + borderBottom / 2
-          });
-          (this.tableGroup.border.firstChild as IRect)?.setAttributes({
-            x: borderLeft / 2,
-            y: borderTop / 2,
-            width: this.tableGroup.attribute.width,
-            height: this.tableGroup.attribute.height
-          });
-        }
-      }
-    }
-
     const hasFrozenCols = this.table.frozenColCount > 0;
     const hasRightFrozenCols = this.table.rightFrozenColCount > 0;
     const hasFrozenRows = this.table.frozenRowCount > 0;
@@ -1510,8 +1438,104 @@ export class Scenegraph {
       });
     }
 
+    if (hasBottomFrozenRows && !this.table.containerFit?.height) {
+      const actualContentBottom = Math.max(
+        this.colHeaderGroup.attribute.y + this.colHeaderGroup.attribute.height,
+        this.cornerHeaderGroup.attribute.y + this.cornerHeaderGroup.attribute.height,
+        this.rightTopCornerGroup.attribute.y + this.rightTopCornerGroup.attribute.height,
+        this.rowHeaderGroup.attribute.y + this.rowHeaderGroup.attribute.height,
+        this.bodyGroup.attribute.y + this.bodyGroup.attribute.height,
+        this.rightFrozenGroup.attribute.y + this.rightFrozenGroup.attribute.height,
+        this.leftBottomCornerGroup.attribute.y + this.leftBottomCornerGroup.attribute.height,
+        this.bottomFrozenGroup.attribute.y + this.bottomFrozenGroup.attribute.height,
+        this.rightBottomCornerGroup.attribute.y + this.rightBottomCornerGroup.attribute.height
+      );
+
+      if (actualContentBottom > 0 && actualContentBottom < this.tableGroup.attribute.height) {
+        this.tableGroup.setAttribute('height', actualContentBottom);
+      }
+    }
+
+    this.updateTableGroupBorder();
+
     // update dom container size
     this.updateDomContainer();
+  }
+
+  updateTableGroupBorder() {
+    if (!this.tableGroup.border) {
+      return;
+    }
+
+    const rectAttributes = this.tableGroup.border?.attribute;
+    let borderTop;
+    let borderRight;
+    let borderBottom;
+    let borderLeft;
+    if ((rectAttributes as any)?.strokeArrayWidth) {
+      borderTop = (rectAttributes as any).strokeArrayWidth
+        ? (rectAttributes as any).strokeArrayWidth[0]
+        : (rectAttributes.lineWidth as number) ?? 0;
+      borderRight = (rectAttributes as any).strokeArrayWidth
+        ? (rectAttributes as any).strokeArrayWidth[1]
+        : (rectAttributes.lineWidth as number) ?? 0;
+      borderBottom = (rectAttributes as any).strokeArrayWidth
+        ? (rectAttributes as any).strokeArrayWidth[2]
+        : (rectAttributes.lineWidth as number) ?? 0;
+      borderLeft = (rectAttributes as any).strokeArrayWidth
+        ? (rectAttributes as any).strokeArrayWidth[3]
+        : (rectAttributes.lineWidth as number) ?? 0;
+    } else {
+      borderTop = (rectAttributes?.lineWidth as number) ?? 0;
+      borderRight = (rectAttributes?.lineWidth as number) ?? 0;
+      borderBottom = (rectAttributes?.lineWidth as number) ?? 0;
+      borderLeft = (rectAttributes?.lineWidth as number) ?? 0;
+    }
+    if (this.tableGroup.border.type === 'rect') {
+      if (this.table.theme.frameStyle?.innerBorder) {
+        this.tableGroup.border.setAttributes({
+          x: this.table.tableX + borderLeft / 2,
+          y: this.table.tableY + borderTop / 2,
+          width: this.tableGroup.attribute.width - borderLeft / 2 - borderRight / 2,
+          height: this.tableGroup.attribute.height - borderTop / 2 - borderBottom / 2
+        });
+      } else {
+        this.tableGroup.border.setAttributes({
+          x: this.table.tableX - borderLeft / 2,
+          y: this.table.tableY - borderTop / 2,
+          width: this.tableGroup.attribute.width + borderLeft / 2 + borderRight / 2,
+          height: this.tableGroup.attribute.height + borderTop / 2 + borderBottom / 2
+        });
+      }
+    } else if (this.tableGroup.border.type === 'group') {
+      if (this.table.theme.frameStyle?.innerBorder) {
+        this.tableGroup.border.setAttributes({
+          x: this.table.tableX + borderLeft / 2,
+          y: this.table.tableY + borderTop / 2,
+          width: this.tableGroup.attribute.width - borderLeft / 2 - borderRight / 2,
+          height: this.tableGroup.attribute.height - borderTop / 2 - borderBottom / 2
+        });
+        (this.tableGroup.border.firstChild as IRect)?.setAttributes({
+          x: 0,
+          y: 0,
+          width: this.tableGroup.attribute.width - borderLeft / 2 - borderRight / 2,
+          height: this.tableGroup.attribute.height - borderTop / 2 - borderBottom / 2
+        });
+      } else {
+        this.tableGroup.border.setAttributes({
+          x: this.table.tableX - borderLeft / 2,
+          y: this.table.tableY - borderTop / 2,
+          width: this.tableGroup.attribute.width + borderLeft / 2 + borderRight / 2,
+          height: this.tableGroup.attribute.height + borderTop / 2 + borderBottom / 2
+        });
+        (this.tableGroup.border.firstChild as IRect)?.setAttributes({
+          x: borderLeft / 2,
+          y: borderTop / 2,
+          width: this.tableGroup.attribute.width,
+          height: this.tableGroup.attribute.height
+        });
+      }
+    }
   }
 
   updateRowHeight(row: number, detaY: number, skipTableHeightMap?: boolean) {


### PR DESCRIPTION
## Summary
- Align the table frame border with the actual bottom frozen row position for short-content list tables.
- Keep previous bottom frozen positioning behavior intact after final layout adjustment.
- Add a local debug demo and regression test for issue #5277.

## Test plan
- [x] Verified local demo `issue-5277-frozen-row-border`: `tableGroupHeight=280`, `bottomFrozenBottom=280`, `borderHeight=281`.
- [x] Verified existing bottom frozen scenarios still pass runtime assertions, including short body, empty body under header, and right frozen body placement.
- [x] Added BugServer photo case for #5277: https://bugserver.cn.goofy.app/case?product=VTable&fileid=6a83c8713335650068dcf413
- [x] Added BugServer photo case for bottom frozen short content: https://bugserver.cn.goofy.app/case?product=VTable&fileid=6a83c88f652957005d019ab2
- [x] Commit hooks passed: `rush lint-staged` and `rush commitlint`.
- [ ] Focused Jest is blocked by workspace resolution for `@visactor/vtable-editors`.
- [ ] Pre-push `rush test --only tag:package` is blocked by unrelated package resolution/formula test failures; pushed with `--no-verify` after maintainer confirmation.

🤖 Generated with Claude Code