### PR TITLE
Fix/issue 3975 tree checkbox row move

### DIFF
--- a/common/changes/@visactor/vtable/fix-issue-3975-tree-checkbox-row-move_2026-08-19-19-18.json
+++ b/common/changes/@visactor/vtable/fix-issue-3975-tree-checkbox-row-move_2026-08-19-19-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@visactor/vtable",
+      "comment": "fix: preserve tree checkbox state after row drag reorder (GitHub #3975)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@visactor/vtable",
+  "email": "892739385@qq.com"
+}

--- a/packages/vtable/__tests__/listTable-checkbox-record-index.test.ts
+++ b/packages/vtable/__tests__/listTable-checkbox-record-index.test.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import { ListTable, TYPES } from '../src';
+import { changeCheckboxOrder } from '../src/state/checkbox/checkbox';
 import { createDiv } from './dom';
 
 global.__VERSION__ = 'none';
@@ -159,5 +160,55 @@ describe('ListTable checkbox record index api', () => {
     expect(table.stateManager.checkedState.get('0').task).toBe(false);
     expect(table.stateManager.checkedState.get('0,0').task).toBe(false);
     expect(table.stateManager.checkedState.get('0,1').task).toBe(false);
+  });
+
+  test('moves checkbox state for a tree subtree by record path', () => {
+    const checkedState = new Map([
+      ['0', { task: 'source' }],
+      ['0,0', { task: 'source-child' }],
+      ['1', { task: 'sibling-1' }],
+      ['1,0', { task: 'sibling-1-child' }],
+      ['2', { task: 'sibling-2' }]
+    ]);
+
+    changeCheckboxOrder(0, 2, { checkedState });
+
+    expect(checkedState.get('2').task).toBe('source');
+    expect(checkedState.get('2,0').task).toBe('source-child');
+    expect(checkedState.get('0').task).toBe('sibling-1');
+    expect(checkedState.get('0,0').task).toBe('sibling-1-child');
+    expect(checkedState.get('1').task).toBe('sibling-2');
+    expect(checkedState.size).toBe(5);
+  });
+
+  test('moves nested checkbox state without matching sibling prefix numbers', () => {
+    const checkedState = new Map([
+      ['0,1', { task: 'source' }],
+      ['0,1,0', { task: 'source-child' }],
+      ['0,2', { task: 'sibling-2' }],
+      ['0,10', { task: 'sibling-10' }],
+      ['0,10,0', { task: 'sibling-10-child' }]
+    ]);
+
+    changeCheckboxOrder([0, 1], [0, 2], { checkedState });
+
+    expect(checkedState.get('0,2').task).toBe('source');
+    expect(checkedState.get('0,2,0').task).toBe('source-child');
+    expect(checkedState.get('0,1').task).toBe('sibling-2');
+    expect(checkedState.get('0,10').task).toBe('sibling-10');
+    expect(checkedState.get('0,10,0').task).toBe('sibling-10-child');
+    expect(checkedState.size).toBe(5);
+  });
+
+  test('does not move checkbox state across different parent paths', () => {
+    const checkedState = new Map([
+      ['0,0', { task: 'source' }],
+      ['1,0', { task: 'target-parent-child' }]
+    ]);
+
+    changeCheckboxOrder([0, 0], [1, 0], { checkedState });
+
+    expect(checkedState.get('0,0').task).toBe('source');
+    expect(checkedState.get('1,0').task).toBe('target-parent-child');
   });
 });

--- a/packages/vtable/__tests__/listTable-checkbox-record-index.test.ts
+++ b/packages/vtable/__tests__/listTable-checkbox-record-index.test.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import { ListTable, TYPES } from '../src';
 import { changeCheckboxOrder } from '../src/state/checkbox/checkbox';
+import { changeRadioOrder } from '../src/state/radio/radio';
 import { createDiv } from './dom';
 
 global.__VERSION__ = 'none';
@@ -200,7 +201,7 @@ describe('ListTable checkbox record index api', () => {
     expect(checkedState.size).toBe(5);
   });
 
-  test('does not move checkbox state across different parent paths', () => {
+  test('keeps checkbox state unchanged for unsupported cross-parent row moves', () => {
     const checkedState = new Map([
       ['0,0', { task: 'source' }],
       ['1,0', { task: 'target-parent-child' }]
@@ -210,5 +211,75 @@ describe('ListTable checkbox record index api', () => {
 
     expect(checkedState.get('0,0').task).toBe('source');
     expect(checkedState.get('1,0').task).toBe('target-parent-child');
+  });
+
+  test('moves flat radio state by record path', () => {
+    const radioState = {
+      columnRadio: 0,
+      cellRadio: {
+        0: 0,
+        1: 1,
+        2: 2
+      }
+    };
+
+    changeRadioOrder(0, 2, { radioState });
+
+    expect(radioState.columnRadio).toBe(2);
+    expect(radioState.cellRadio[2]).toBe(0);
+    expect(radioState.cellRadio[0]).toBe(1);
+    expect(radioState.cellRadio[1]).toBe(2);
+  });
+
+  test('moves nested radio state without matching sibling prefix numbers', () => {
+    const radioState = {
+      cellRadio: {
+        '0,1': true,
+        '0,1,0': 1,
+        '0,2': true,
+        '0,10': true
+      }
+    };
+
+    changeRadioOrder([0, 1], [0, 2], { radioState });
+
+    expect(radioState.cellRadio['0,2']).toBe(true);
+    expect(radioState.cellRadio['0,2,0']).toBe(1);
+    expect(radioState.cellRadio['0,1']).toBe(true);
+    expect(radioState.cellRadio['0,10']).toBe(true);
+  });
+
+  test('keeps radio state unchanged for unsupported cross-parent row moves', () => {
+    const radioState = {
+      cellRadio: {
+        '0,0': 1,
+        '1,0': 2
+      }
+    };
+
+    changeRadioOrder([0, 0], [1, 0], { radioState });
+
+    expect(radioState.cellRadio['0,0']).toBe(1);
+    expect(radioState.cellRadio['1,0']).toBe(2);
+  });
+
+  test('StateManager moves radio state stored as an object', () => {
+    table = new ListTable({
+      container: createDiv(),
+      columns: [
+        {
+          field: 'choice',
+          title: 'Choice',
+          cellType: 'radio',
+          width: 120
+        }
+      ],
+      records: [{ choice: true }, { choice: false }, { choice: false }]
+    });
+    table.stateManager.radioState = { choice: 0 };
+
+    table.stateManager.changeRadioOrder(0, 2);
+
+    expect(table.stateManager.radioState.choice).toBe(2);
   });
 });

--- a/packages/vtable/__tests__/listTable-checkbox-record-index.test.ts
+++ b/packages/vtable/__tests__/listTable-checkbox-record-index.test.ts
@@ -249,6 +249,16 @@ describe('ListTable checkbox record index api', () => {
     expect(radioState.cellRadio['0,10']).toBe(true);
   });
 
+  test('moves serialized radio record path state', () => {
+    const radioState = {
+      columnRadio: '0,1'
+    };
+
+    changeRadioOrder([0, 1], [0, 2], { radioState });
+
+    expect(radioState.columnRadio).toBe('0,2');
+  });
+
   test('keeps radio state unchanged for unsupported cross-parent row moves', () => {
     const radioState = {
       cellRadio: {

--- a/packages/vtable/examples/list/issue-3975-tree-checkbox-row-move.ts
+++ b/packages/vtable/examples/list/issue-3975-tree-checkbox-row-move.ts
@@ -1,0 +1,171 @@
+import * as VTable from '../../src';
+
+const CONTAINER_ID = 'vTable';
+const CHECKBOX_FIELD = 'task';
+
+function getRecordByPath(records: any[], path: number[]) {
+  let current: any = records;
+  for (let i = 0; i < path.length; i++) {
+    current = current?.[path[i]];
+    if (i < path.length - 1) {
+      current = current?.children;
+    }
+  }
+  return current;
+}
+
+function getTaskText(record: any): string {
+  return typeof record?.task === 'object' ? record.task.text : record?.task;
+}
+
+function getChecked(table: VTable.ListTable, path: number[]) {
+  return table.stateManager.checkedState.get(path.toString())?.[CHECKBOX_FIELD];
+}
+
+function createRecords() {
+  return [
+    {
+      task: 'Project A',
+      owner: 'Alice',
+      status: 'checked before move',
+      hierarchyState: VTable.TYPES.HierarchyState.expand,
+      children: [
+        {
+          task: 'Task A-1',
+          owner: 'Bob',
+          status: 'checked before move'
+        },
+        {
+          task: 'Task A-2',
+          owner: 'Cindy',
+          status: 'unchecked'
+        }
+      ]
+    },
+    {
+      task: 'Project B',
+      owner: 'David',
+      status: 'unchecked'
+    },
+    {
+      task: 'Project C',
+      owner: 'Emily',
+      status: 'unchecked'
+    }
+  ];
+}
+
+export function createTable() {
+  const records = createRecords();
+  const container = document.getElementById(CONTAINER_ID);
+  if (container) {
+    container.style.width = '1000px';
+    container.style.height = '520px';
+  }
+
+  const option: VTable.ListTableConstructorOptions = {
+    container,
+    records,
+    rowSeriesNumber: {
+      title: '',
+      dragOrder: true,
+      width: 46
+    },
+    columns: [
+      {
+        field: CHECKBOX_FIELD,
+        title: 'Task',
+        tree: true,
+        cellType: 'checkbox',
+        headerType: 'checkbox',
+        width: 260
+      },
+      { field: 'owner', title: 'Owner', width: 120 },
+      { field: 'status', title: 'Status', width: 220 }
+    ],
+    defaultRowHeight: 38,
+    hierarchyIndent: 20,
+    hierarchyExpandLevel: 2,
+    enableCheckboxCascade: false,
+    enableHeaderCheckboxCascade: false,
+    theme: VTable.themes.BRIGHT
+  };
+
+  const tableInstance = new VTable.ListTable(option);
+  window.tableInstance = tableInstance;
+
+  tableInstance.setCellCheckboxStateByRecordIndex(0, CHECKBOX_FIELD, true);
+  tableInstance.setCellCheckboxStateByRecordIndex([0, 0], CHECKBOX_FIELD, true);
+
+  const toolbar = document.createElement('div');
+  toolbar.style.cssText = [
+    'position:absolute',
+    'top:8px',
+    'left:8px',
+    'right:8px',
+    'z-index:10',
+    'display:flex',
+    'align-items:flex-start',
+    'gap:8px',
+    'font:12px sans-serif'
+  ].join(';');
+
+  const moveButton = document.createElement('button');
+  moveButton.textContent = 'Move Project A after Project C';
+
+  const resetButton = document.createElement('button');
+  resetButton.textContent = 'Reset';
+
+  const status = document.createElement('pre');
+  status.style.cssText = [
+    'margin:0',
+    'padding:8px 10px',
+    'background:rgba(255,255,255,0.92)',
+    'border:1px solid #d0d7de',
+    'border-radius:4px',
+    'line-height:1.5',
+    'min-width:520px'
+  ].join(';');
+
+  const renderStatus = (label: string) => {
+    const data = tableInstance.records as any[];
+    const projectAAt2 = getTaskText(getRecordByPath(data, [2])) === 'Project A';
+    const taskA1At20 = getTaskText(getRecordByPath(data, [2, 0])) === 'Task A-1';
+    const projectAChecked = getChecked(tableInstance, [2]) === true;
+    const taskA1Checked = getChecked(tableInstance, [2, 0]) === true;
+    const staleChildState = tableInstance.stateManager.checkedState.get('0,0')?.[CHECKBOX_FIELD] === true;
+
+    status.textContent = [
+      label,
+      `record order: ${data.map(record => getTaskText(record)).join(' -> ')}`,
+      `Project A at [2]: ${projectAAt2 ? 'yes' : 'no'}, checked: ${projectAChecked ? 'yes' : 'no'}`,
+      `Task A-1 at [2,0]: ${taskA1At20 ? 'yes' : 'no'}, checked: ${taskA1Checked ? 'yes' : 'no'}`,
+      `stale checkedState at old [0,0]: ${staleChildState ? 'yes' : 'no'}`,
+      `result: ${projectAAt2 && taskA1At20 && projectAChecked && taskA1Checked && !staleChildState ? 'fixed' : 'repro'}`
+    ].join('\n');
+  };
+
+  moveButton.onclick = () => {
+    tableInstance.changeHeaderPosition({
+      source: { col: 0, row: 1 },
+      target: { col: 0, row: 5 },
+      movingColumnOrRow: 'row'
+    });
+    renderStatus('after moving Project A from [0] to [2]');
+  };
+
+  resetButton.onclick = () => {
+    tableInstance.release();
+    toolbar.remove();
+    createTable();
+  };
+
+  toolbar.appendChild(moveButton);
+  toolbar.appendChild(resetButton);
+  toolbar.appendChild(status);
+  document.body.appendChild(toolbar);
+
+  renderStatus('before move: Project A and Task A-1 are checked');
+
+  return tableInstance;
+}

--- a/packages/vtable/examples/menu.ts
+++ b/packages/vtable/examples/menu.ts
@@ -161,6 +161,10 @@ export const menus = [
       },
       {
         path: 'list',
+        name: 'issue-3975-tree-checkbox-row-move'
+      },
+      {
+        path: 'list',
         name: 'list-tree-20000'
       },
       {

--- a/packages/vtable/src/core/BaseTable.ts
+++ b/packages/vtable/src/core/BaseTable.ts
@@ -3605,11 +3605,12 @@ export abstract class BaseTable extends EventTarget implements BaseTableAPI {
 
       if (
         this.isListTable() &&
-        !(this as any).transpose &&
+        !(this as unknown as ListTableAPI).transpose &&
         (this.isSeriesNumberInBody(args.source.col, args.source.row) || args.movingColumnOrRow === 'row')
       ) {
-        const sourceRecordPath = (this as any).getRecordIndexByCell(0, moveContext.sourceIndex);
-        const targetRecordPath = (this as any).getRecordIndexByCell(0, moveContext.targetIndex);
+        const listTable = this as unknown as ListTableAPI;
+        const sourceRecordPath = listTable.getRecordIndexByCell(args.source.col, moveContext.sourceIndex);
+        const targetRecordPath = listTable.getRecordIndexByCell(args.target.col, moveContext.targetIndex);
         this.changeRecordOrder(moveContext.sourceIndex, moveContext.targetIndex);
         this.stateManager.changeCheckboxOrder(sourceRecordPath, targetRecordPath);
         this.stateManager.changeRadioOrder(sourceRecordPath, targetRecordPath);

--- a/packages/vtable/src/core/BaseTable.ts
+++ b/packages/vtable/src/core/BaseTable.ts
@@ -3612,7 +3612,7 @@ export abstract class BaseTable extends EventTarget implements BaseTableAPI {
         const targetRecordPath = (this as any).getRecordIndexByCell(0, moveContext.targetIndex);
         this.changeRecordOrder(moveContext.sourceIndex, moveContext.targetIndex);
         this.stateManager.changeCheckboxOrder(sourceRecordPath, targetRecordPath);
-        this.stateManager.changeRadioOrder(moveContext.sourceIndex, moveContext.targetIndex);
+        this.stateManager.changeRadioOrder(sourceRecordPath, targetRecordPath);
       }
 
       if (moveContext.moveType === 'column') {

--- a/packages/vtable/src/core/BaseTable.ts
+++ b/packages/vtable/src/core/BaseTable.ts
@@ -3604,11 +3604,15 @@ export abstract class BaseTable extends EventTarget implements BaseTableAPI {
       }
 
       if (
+        this.isListTable() &&
         !(this as any).transpose &&
         (this.isSeriesNumberInBody(args.source.col, args.source.row) || args.movingColumnOrRow === 'row')
       ) {
+        const sourceRecordPath = (this as any).getRecordIndexByCell(0, moveContext.sourceIndex);
+        const targetRecordPath = (this as any).getRecordIndexByCell(0, moveContext.targetIndex);
         this.changeRecordOrder(moveContext.sourceIndex, moveContext.targetIndex);
-        this.stateManager.changeCheckboxAndRadioOrder(moveContext.sourceIndex, moveContext.targetIndex);
+        this.stateManager.changeCheckboxOrder(sourceRecordPath, targetRecordPath);
+        this.stateManager.changeRadioOrder(moveContext.sourceIndex, moveContext.targetIndex);
       }
 
       if (moveContext.moveType === 'column') {

--- a/packages/vtable/src/state/cell-move/index.ts
+++ b/packages/vtable/src/state/cell-move/index.ts
@@ -244,7 +244,7 @@ export function endMoveCol(state: StateManager): boolean {
         const targetRecordPath = (state.table as ListTable).getRecordIndexByCell(0, moveContext.targetIndex);
         state.table.changeRecordOrder(moveContext.sourceIndex, moveContext.targetIndex);
         state.changeCheckboxOrder(sourceRecordPath, targetRecordPath);
-        state.changeRadioOrder(moveContext.sourceIndex, moveContext.targetIndex);
+        state.changeRadioOrder(sourceRecordPath, targetRecordPath);
       }
       // clear columns width and rows height cache
       if (moveContext.moveType === 'column') {

--- a/packages/vtable/src/state/cell-move/index.ts
+++ b/packages/vtable/src/state/cell-move/index.ts
@@ -232,6 +232,7 @@ export function endMoveCol(state: StateManager): boolean {
         }
       }
       if (
+        state.table.isListTable() &&
         !(state.table as ListTable).transpose &&
         ((state.table.internalProps.layoutMap as SimpleHeaderLayoutMap).isSeriesNumberInBody(
           state.columnMove.colSource,
@@ -239,8 +240,11 @@ export function endMoveCol(state: StateManager): boolean {
         ) ||
           state.columnMove.movingColumnOrRow === 'row')
       ) {
+        const sourceRecordPath = (state.table as ListTable).getRecordIndexByCell(0, moveContext.sourceIndex);
+        const targetRecordPath = (state.table as ListTable).getRecordIndexByCell(0, moveContext.targetIndex);
         state.table.changeRecordOrder(moveContext.sourceIndex, moveContext.targetIndex);
-        state.changeCheckboxAndRadioOrder(moveContext.sourceIndex, moveContext.targetIndex);
+        state.changeCheckboxOrder(sourceRecordPath, targetRecordPath);
+        state.changeRadioOrder(moveContext.sourceIndex, moveContext.targetIndex);
       }
       // clear columns width and rows height cache
       if (moveContext.moveType === 'column') {

--- a/packages/vtable/src/state/checkbox/checkbox.ts
+++ b/packages/vtable/src/state/checkbox/checkbox.ts
@@ -413,6 +413,7 @@ export function changeCheckboxOrder(sourceRecordPath: RecordPath, targetRecordPa
   const sourcePath = normalizeRecordPath(sourceRecordPath);
   const targetPath = normalizeRecordPath(targetRecordPath);
 
+  // DataSource.changeOrder only reorders records under the same parent; cross-parent drops are ignored here.
   if (isSameRecordPath(sourcePath, targetPath) || !isSameParentPath(sourcePath, targetPath)) {
     return;
   }

--- a/packages/vtable/src/state/checkbox/checkbox.ts
+++ b/packages/vtable/src/state/checkbox/checkbox.ts
@@ -356,68 +356,89 @@ export function setCellCheckboxStateByAttribute(
   }
 }
 
-export function changeCheckboxOrder(sourceIndex: number, targetIndex: number, state: StateManager) {
-  const { checkedState, table } = state;
-  let source;
-  let target;
-  if (table.internalProps.transpose) {
-    sourceIndex = table.getRecordShowIndexByCell(sourceIndex, 0);
-    targetIndex = table.getRecordShowIndexByCell(targetIndex, 0);
-  } else {
-    // sourceIndex = table.getRecordShowIndexByCell(0, sourceIndex);
-    // targetIndex = table.getRecordShowIndexByCell(0, targetIndex);
+type RecordPath = number | number[];
 
-    source = table.isPivotTable() ? undefined : (table as any).getRecordIndexByCell(0, sourceIndex);
-    target = table.isPivotTable() ? undefined : (table as any).getRecordIndexByCell(0, targetIndex);
+function normalizeRecordPath(recordPath: RecordPath): number[] {
+  return isArray(recordPath) ? recordPath : [recordPath];
+}
+
+function parseCheckboxStateKey(key: string | number): number[] {
+  return isNumber(key) ? [key] : key.split(',').map(item => Number(item));
+}
+
+function stringifyRecordPath(recordPath: number[]): string {
+  return recordPath.toString();
+}
+
+function isSameRecordPath(source: number[], target: number[]): boolean {
+  return source.length === target.length && source.every((item, index) => item === target[index]);
+}
+
+function isSameParentPath(source: number[], target: number[]): boolean {
+  if (source.length !== target.length) {
+    return false;
+  }
+  return source.slice(0, -1).every((item, index) => item === target[index]);
+}
+
+function isDescendantPath(path: number[], ancestor: number[]): boolean {
+  return ancestor.length <= path.length && ancestor.every((item, index) => item === path[index]);
+}
+
+function getMovedRecordPath(path: number[], source: number[], target: number[]): number[] {
+  return target.concat(path.slice(source.length));
+}
+
+function getShiftedSiblingPath(path: number[], parent: number[], sourceIndex: number, targetIndex: number): number[] {
+  if (path.length <= parent.length || !isDescendantPath(path.slice(0, parent.length), parent)) {
+    return path;
   }
 
-  if (isNumber(source) && isNumber(target)) {
-    sourceIndex = source;
-    targetIndex = target;
-    if (sourceIndex > targetIndex) {
-      const sourceRecord = checkedState.get(sourceIndex.toString());
-      for (let i = sourceIndex; i > targetIndex; i--) {
-        // checkedState[i] = checkedState[i - 1];
-        checkedState.set(i.toString(), checkedState.get((i - 1).toString()));
-      }
-      // checkedState[targetIndex] = sourceRecord;
-      checkedState.set(targetIndex.toString(), sourceRecord);
-    } else if (sourceIndex < targetIndex) {
-      const sourceRecord = checkedState.get(sourceIndex.toString());
-      for (let i = sourceIndex; i < targetIndex; i++) {
-        // checkedState[i] = checkedState[i + 1];
-        checkedState.set(i.toString(), checkedState.get((i + 1).toString()));
-      }
-      // checkedState[targetIndex] = sourceRecord;
-      checkedState.set(targetIndex.toString(), sourceRecord);
-    }
-  } else if (isArray(source) && isArray(target)) {
-    sourceIndex = source[source.length - 1];
-    targetIndex = target[target.length - 1];
-    if (sourceIndex > targetIndex) {
-      const sourceRecord = checkedState.get(source.toString());
-      for (let i = sourceIndex; i > targetIndex; i--) {
-        const now = [...source];
-        now[now.length - 1] = i;
-        const last = [...source];
-        last[last.length - 1] = i - 1;
-        checkedState.set(now.toString(), checkedState.get(last.toString()));
-      }
-      // checkedState[targetIndex] = sourceRecord;
-      checkedState.set(target.toString(), sourceRecord);
-    } else if (sourceIndex < targetIndex) {
-      const sourceRecord = checkedState.get(source.toString());
-      for (let i = sourceIndex; i < targetIndex; i++) {
-        const now = [...source];
-        now[now.length - 1] = i;
-        const next = [...source];
-        next[next.length - 1] = i + 1;
-        checkedState.set(now.toString(), checkedState.get(next.toString()));
-      }
-      // checkedState[targetIndex] = sourceRecord;
-      checkedState.set(target.toString(), sourceRecord);
-    }
+  const siblingIndex = path[parent.length];
+  if (sourceIndex < targetIndex && siblingIndex > sourceIndex && siblingIndex <= targetIndex) {
+    const shifted = [...path];
+    shifted[parent.length] = siblingIndex - 1;
+    return shifted;
   }
+  if (sourceIndex > targetIndex && siblingIndex >= targetIndex && siblingIndex < sourceIndex) {
+    const shifted = [...path];
+    shifted[parent.length] = siblingIndex + 1;
+    return shifted;
+  }
+  return path;
+}
+
+export function changeCheckboxOrder(sourceRecordPath: RecordPath, targetRecordPath: RecordPath, state: StateManager) {
+  const { checkedState } = state;
+  const sourcePath = normalizeRecordPath(sourceRecordPath);
+  const targetPath = normalizeRecordPath(targetRecordPath);
+
+  if (isSameRecordPath(sourcePath, targetPath) || !isSameParentPath(sourcePath, targetPath)) {
+    return;
+  }
+
+  const parentPath = sourcePath.slice(0, -1);
+  const sourceIndex = sourcePath[sourcePath.length - 1];
+  const targetIndex = targetPath[targetPath.length - 1];
+  const nextCheckedState = new Map<string | number, Record<string | number, boolean | 'indeterminate'>>();
+
+  checkedState.forEach((value, key) => {
+    const keyPath = parseCheckboxStateKey(key);
+    let nextPath: number[];
+
+    if (isDescendantPath(keyPath, sourcePath)) {
+      nextPath = getMovedRecordPath(keyPath, sourcePath, targetPath);
+    } else {
+      nextPath = getShiftedSiblingPath(keyPath, parentPath, sourceIndex, targetIndex);
+    }
+
+    nextCheckedState.set(stringifyRecordPath(nextPath), value);
+  });
+
+  checkedState.clear();
+  nextCheckedState.forEach((value, key) => {
+    checkedState.set(key, value);
+  });
 }
 
 export function getGroupCheckboxState(table: BaseTableAPI) {

--- a/packages/vtable/src/state/radio/radio.ts
+++ b/packages/vtable/src/state/radio/radio.ts
@@ -4,6 +4,9 @@ import type { BaseTableAPI } from '../../ts-types/base-table';
 import type { ColumnDefine } from '../../ts-types';
 import type { Radio } from '@src/vrender';
 
+type RecordPath = number | number[];
+type RadioStateValue = boolean | number | number[] | Record<string | number, boolean | number>;
+
 export function setRadioState(
   col: number,
   row: number,
@@ -139,31 +142,99 @@ export function setCellRadioState(col: number, row: number, index: number | unde
   }
 }
 
-export function changeRadioOrder(sourceIndex: number, targetIndex: number, state: StateManager) {
-  const { radioState, table } = state;
-  if (table.internalProps.transpose) {
-    sourceIndex = table.getRecordShowIndexByCell(sourceIndex, 0);
-    targetIndex = table.getRecordShowIndexByCell(targetIndex, 0);
-  } else {
-    sourceIndex = table.getRecordShowIndexByCell(0, sourceIndex);
-    targetIndex = table.getRecordShowIndexByCell(0, targetIndex);
+function normalizeRecordPath(recordPath: RecordPath): number[] {
+  return Array.isArray(recordPath) ? recordPath : [recordPath];
+}
+
+function parseRecordPathKey(key: string | number): number[] {
+  return isNumber(key) ? [key] : key.split(',').map(item => Number(item));
+}
+
+function isSameRecordPath(source: number[], target: number[]): boolean {
+  return source.length === target.length && source.every((item, index) => item === target[index]);
+}
+
+function isSameParentPath(source: number[], target: number[]): boolean {
+  if (source.length !== target.length) {
+    return false;
   }
-  // if (sourceIndex !== targetIndex) {
-  //   const sourceRecord = radioState[sourceIndex];
-  //   radioState[sourceIndex] = radioState[targetIndex];
-  //   radioState[targetIndex] = sourceRecord;
-  // }
-  if (sourceIndex > targetIndex) {
-    const sourceRecord = radioState[sourceIndex];
-    for (let i = sourceIndex; i > targetIndex; i--) {
-      radioState[i] = radioState[i - 1];
-    }
-    radioState[targetIndex] = sourceRecord;
-  } else if (sourceIndex < targetIndex) {
-    const sourceRecord = radioState[sourceIndex];
-    for (let i = sourceIndex; i < targetIndex; i++) {
-      radioState[i] = radioState[i + 1];
-    }
-    radioState[targetIndex] = sourceRecord;
+  return source.slice(0, -1).every((item, index) => item === target[index]);
+}
+
+function isDescendantPath(path: number[], ancestor: number[]): boolean {
+  return ancestor.length <= path.length && ancestor.every((item, index) => item === path[index]);
+}
+
+function getMovedRecordPath(path: number[], source: number[], target: number[]): number[] {
+  return target.concat(path.slice(source.length));
+}
+
+function getShiftedSiblingPath(path: number[], parent: number[], sourceIndex: number, targetIndex: number): number[] {
+  if (path.length <= parent.length || !isDescendantPath(path.slice(0, parent.length), parent)) {
+    return path;
   }
+
+  const siblingIndex = path[parent.length];
+  if (sourceIndex < targetIndex && siblingIndex > sourceIndex && siblingIndex <= targetIndex) {
+    const shifted = [...path];
+    shifted[parent.length] = siblingIndex - 1;
+    return shifted;
+  }
+  if (sourceIndex > targetIndex && siblingIndex >= targetIndex && siblingIndex < sourceIndex) {
+    const shifted = [...path];
+    shifted[parent.length] = siblingIndex + 1;
+    return shifted;
+  }
+  return path;
+}
+
+function getChangedRecordPath(path: number[], sourcePath: number[], targetPath: number[]): number[] {
+  const parentPath = sourcePath.slice(0, -1);
+  const sourceIndex = sourcePath[sourcePath.length - 1];
+  const targetIndex = targetPath[targetPath.length - 1];
+
+  if (isDescendantPath(path, sourcePath)) {
+    return getMovedRecordPath(path, sourcePath, targetPath);
+  }
+  return getShiftedSiblingPath(path, parentPath, sourceIndex, targetIndex);
+}
+
+function getRadioStateValue(recordPath: number[]): number | number[] {
+  return recordPath.length === 1 ? recordPath[0] : recordPath;
+}
+
+function getRadioStateKey(recordPath: number[]): string {
+  return recordPath.toString();
+}
+
+function changeRadioStateValue(value: RadioStateValue, sourcePath: number[], targetPath: number[]): RadioStateValue {
+  if (isNumber(value)) {
+    return getRadioStateValue(getChangedRecordPath([value], sourcePath, targetPath));
+  }
+  if (Array.isArray(value)) {
+    return getRadioStateValue(getChangedRecordPath(value, sourcePath, targetPath));
+  }
+  if (isObject(value)) {
+    const nextValue: Record<string | number, boolean | number> = {};
+    Object.keys(value).forEach(key => {
+      const nextPath = getChangedRecordPath(parseRecordPathKey(key), sourcePath, targetPath);
+      nextValue[getRadioStateKey(nextPath)] = value[key];
+    });
+    return nextValue;
+  }
+  return value;
+}
+
+export function changeRadioOrder(sourceRecordPath: RecordPath, targetRecordPath: RecordPath, state: StateManager) {
+  const { radioState } = state;
+  const sourcePath = normalizeRecordPath(sourceRecordPath);
+  const targetPath = normalizeRecordPath(targetRecordPath);
+
+  if (isSameRecordPath(sourcePath, targetPath) || !isSameParentPath(sourcePath, targetPath)) {
+    return;
+  }
+
+  Object.keys(radioState).forEach(field => {
+    radioState[field] = changeRadioStateValue(radioState[field] as RadioStateValue, sourcePath, targetPath);
+  });
 }

--- a/packages/vtable/src/state/radio/radio.ts
+++ b/packages/vtable/src/state/radio/radio.ts
@@ -1,11 +1,11 @@
-import { isBoolean, isNumber, isObject, isValid } from '@visactor/vutils';
+import { isBoolean, isNumber, isObject, isString, isValid } from '@visactor/vutils';
 import type { StateManager } from '../state';
 import type { BaseTableAPI } from '../../ts-types/base-table';
 import type { ColumnDefine } from '../../ts-types';
 import type { Radio } from '@src/vrender';
 
 type RecordPath = number | number[];
-type RadioStateValue = boolean | number | number[] | Record<string | number, boolean | number>;
+type RadioStateValue = boolean | number | string | number[] | Record<string | number, boolean | number>;
 
 export function setRadioState(
   col: number,
@@ -213,6 +213,9 @@ function changeRadioStateValue(value: RadioStateValue, sourcePath: number[], tar
   }
   if (Array.isArray(value)) {
     return getRadioStateValue(getChangedRecordPath(value, sourcePath, targetPath));
+  }
+  if (isString(value)) {
+    return getRadioStateKey(getChangedRecordPath(parseRecordPathKey(value), sourcePath, targetPath));
   }
   if (isObject(value)) {
     const nextValue: Record<string | number, boolean | number> = {};

--- a/packages/vtable/src/state/state.ts
+++ b/packages/vtable/src/state/state.ts
@@ -222,7 +222,10 @@ export class StateManager {
 
   _headerCheckFuncs: Record<string | number, Function> = {};
 
-  radioState: Record<string | number, boolean | number | number[] | Record<string | number, boolean | number>> = {};
+  radioState: Record<
+    string | number,
+    boolean | number | string | number[] | Record<string | number, boolean | number>
+  > = {};
   // 供滚动重置为default使用
   resetInteractionState = debounce((state?: InteractionState) => {
     this.updateInteractionState(state ?? InteractionState.default);

--- a/packages/vtable/src/state/state.ts
+++ b/packages/vtable/src/state/state.ts
@@ -222,7 +222,7 @@ export class StateManager {
 
   _headerCheckFuncs: Record<string | number, Function> = {};
 
-  radioState: Record<string | number, boolean | number | Record<number, number>> = {};
+  radioState: Record<string | number, boolean | number | number[] | Record<string | number, boolean | number>> = {};
   // 供滚动重置为default使用
   resetInteractionState = debounce((state?: InteractionState) => {
     this.updateInteractionState(state ?? InteractionState.default);
@@ -1961,9 +1961,9 @@ export class StateManager {
     }
   }
 
-  changeRadioOrder(sourceIndex: number, targetIndex: number) {
-    if (this.radioState.length) {
-      changeRadioOrder(sourceIndex, targetIndex, this);
+  changeRadioOrder(sourceRecordPath: number | number[], targetRecordPath: number | number[]) {
+    if (Object.keys(this.radioState).length) {
+      changeRadioOrder(sourceRecordPath, targetRecordPath, this);
     }
   }
 

--- a/packages/vtable/src/state/state.ts
+++ b/packages/vtable/src/state/state.ts
@@ -1955,10 +1955,13 @@ export class StateManager {
     return syncRadioState(col, row, field, radioType, indexInCell, isChecked, this);
   }
 
-  changeCheckboxAndRadioOrder(sourceIndex: number, targetIndex: number) {
+  changeCheckboxOrder(sourceRecordPath: number | number[], targetRecordPath: number | number[]) {
     if (this.checkedState.size) {
-      changeCheckboxOrder(sourceIndex, targetIndex, this);
+      changeCheckboxOrder(sourceRecordPath, targetRecordPath, this);
     }
+  }
+
+  changeRadioOrder(sourceIndex: number, targetIndex: number) {
     if (this.radioState.length) {
       changeRadioOrder(sourceIndex, targetIndex, this);
     }

--- a/packages/vtable/src/ts-types/table-engine.ts
+++ b/packages/vtable/src/ts-types/table-engine.ts
@@ -364,6 +364,8 @@ export interface ListTableAPI extends BaseTableAPI {
   internalProps: ListTableProtected;
   isListTable: () => true;
   isPivotTable: () => false;
+  /** 获取当前单元格对应源数据 records 的 index；树形表格返回 children 路径。 */
+  getRecordIndexByCell: (col: number, row: number) => number | number[];
   /** 设置单元格的value值，注意对应的是源数据的原始值，vtable实例records会做对应修改 */
   changeCellValue: (
     col: number,


### PR DESCRIPTION
### 🤔 This is a ...

- [x] Bug fix
- [x] Test Case
- [x] Demo update

### 🔗 Related issue link

close #3975

### 💡 Background and solution

Tree ListTable row drag can reorder the underlying records while checkbox state is still keyed by the old record path. When a checked parent and child node are moved, the child checkbox state can stay on the original row path instead of following the moved tree node.

This PR updates checkbox state migration to use real record paths before reordering records. The migration now rebuilds checkbox state from a snapshot, compares path segments numerically, and avoids prefix collisions such as `1` matching `10`. It also keeps transpose ListTable from mutating record order in this path.

A demo is added at `examples/list/issue-3975-tree-checkbox-row-move.ts` to reproduce the old behavior and verify the fixed state after moving `Project A`.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix tree checkbox state after row drag reorder. |
| 🇨🇳 Chinese | 修复树形表格行拖拽后 checkbox 状态未跟随节点移动的问题。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough