### PR TITLE
docs: fix typo defalut -> default

### DIFF
--- a/docs/assets/demo/en/animation/scroll-animation.md
+++ b/docs/assets/demo/en/animation/scroll-animation.md
@@ -14,7 +14,7 @@ Scroll to the specified area of ​​the table through animation.
 
 - `animationOption` scroll animation configuration
   - `duration` animation duration, unit ms
-  - `easing` animation easing function, defalut `linear`, support `linear`, `quadIn`, `quadOut`, `quadInOut`, `quadInOut`, `cubicIn`, `cubicOut`, `cubicInOut`, `quartIn`, `quartOut`, `quartInOut`, `quintIn`, `quintOut`, `quintInOut`, `backIn`, `backOut`, `backInOut`, `circIn`, `circOut`, `circInOut`, `bounceOut`, `bounceIn`, `bounceInOut`, `elasticIn`, `elasticOut`, `elasticInOut`, `sineIn`, `sineOut`, `sineInOut`, `expoIn`, `expoOut`, `expoInOut`
+  - `easing` animation easing function, default `linear`, support `linear`, `quadIn`, `quadOut`, `quadInOut`, `quadInOut`, `cubicIn`, `cubicOut`, `cubicInOut`, `quartIn`, `quartOut`, `quartInOut`, `quintIn`, `quintOut`, `quintInOut`, `backIn`, `backOut`, `backInOut`, `circIn`, `circOut`, `circInOut`, `bounceOut`, `bounceIn`, `bounceInOut`, `elasticIn`, `elasticOut`, `elasticInOut`, `sineIn`, `sineOut`, `sineInOut`, `expoIn`, `expoOut`, `expoInOut`
 - `scrollToCell({col, row}, animationOption)` scroll to specified cell
 - `scrollToRow(row, animationOption)` scroll to specified row
 - `scrollToCol(col, animationOption)` scroll to specified column


### PR DESCRIPTION
One-word typo fix in `docs/assets/demo/en/animation/scroll-animation.md:17`, in the `easing` option description: "defalut" -> "default".
