### PR TITLE
fix: support dynamic gantt mark line styles

### DIFF
--- a/docs/assets/demo/en/gantt/gantt-zoom.md
+++ b/docs/assets/demo/en/gantt/gantt-zoom.md
@@ -19,6 +19,7 @@ The Gantt chart smart zoom feature provides multi-level timeline display schemes
 - API get current zoom state: Use methods provided by `getCurrentZoomState`
 - API set current zoom state: Use methods provided by `setZoomPosition`
 - API zooming: Use zoom methods provided by `zoomScaleManager`
+- `markLine.style.lineWidth`: Can be configured as a function to calculate the mark line width from the current zoomed timeline column width
 
 ## Demo
 
@@ -729,6 +730,27 @@ const option = {
       lineColor: '#f1f3f4'
     }
   },
+  markLine: [
+    {
+      date: '2024-07-17',
+      content: 'Dynamic width',
+      style: {
+        lineWidth: ({ timelineColWidth }) => Math.max(1, Math.round(timelineColWidth / 20)),
+        lineColor: 'blue',
+        lineDash: [8, 4]
+      }
+    },
+    {
+      date: '2024-08-17',
+      content: 'Fixed width',
+      position: 'middle',
+      style: {
+        lineWidth: 2,
+        lineColor: 'red',
+        lineDash: [8, 4]
+      }
+    }
+  ],
   headerRowHeight: 50,
   rowHeight: 40,
   overscrollBehavior: 'none'

--- a/docs/assets/demo/zh/gantt/gantt-zoom.md
+++ b/docs/assets/demo/zh/gantt/gantt-zoom.md
@@ -19,6 +19,7 @@ option: Gantt#zoomScale
 - API 获得当前缩放状态：使用 `getCurrentZoomState` 提供的方法
 - API 设置当前缩放状态：使用 `setZoomPosition` 提供的方法
 - API 缩放：使用 `zoomScaleManager` 提供的缩放方法
+- `markLine.style.lineWidth`: 可配置函数，根据当前缩放后的时间轴列宽动态计算标记线宽度
 
 ## 代码演示
 
@@ -700,6 +701,27 @@ const option = {
       lineColor: '#f1f3f4'
     }
   },
+  markLine: [
+    {
+      date: '2024-07-17',
+      content: '动态宽度',
+      style: {
+        lineWidth: ({ timelineColWidth }) => Math.max(1, Math.round(timelineColWidth / 20)),
+        lineColor: 'blue',
+        lineDash: [8, 4]
+      }
+    },
+    {
+      date: '2024-08-17',
+      content: '固定宽度',
+      position: 'middle',
+      style: {
+        lineWidth: 2,
+        lineColor: 'red',
+        lineDash: [8, 4]
+      }
+    }
+  ],
   headerRowHeight: 50,
   rowHeight: 40,
   overscrollBehavior: 'none'

--- a/docs/assets/guide/en/gantt/gantt_markline.md
+++ b/docs/assets/guide/en/gantt/gantt_markline.md
@@ -15,12 +15,12 @@ The configuration items of IMarkLine are as follows:
 ```javascript
 export interface IMarkLine {
   date: string;
-  style?: ILineStyle;
+  style?: IMarkLineStyle | ((args: IMarkLineStyleArgumentType) => IMarkLineStyle);
   /** The position of the mark line under the date column. The default is 'left'. */
   position?: 'left' | 'right' | 'middle' | 'date';
-    /** Automatically scroll the date range to include this mark line. */
+  /** Automatically scroll the date range to include this mark line. */
   scrollToMarkLine?: boolean;
-  content?: string; // markLine中内容
+  content?: string; // markLine content
   /** The style of the content in the markLine. */
   contentStyle?: {
     color?: string;
@@ -31,6 +31,20 @@ export interface IMarkLine {
     cornerRadius?: string;
   }
 }
+
+export type IMarkLineStyle = Omit<ILineStyle, 'lineWidth'> & {
+  lineWidth?: number | ((args: IMarkLineStyleArgumentType) => number);
+};
+
+export type IMarkLineStyleArgumentType = {
+  date: Date;
+  dateIndex: number;
+  dateX: number;
+  cellStartX: number;
+  cellWidth: number;
+  timelineColWidth: number;
+  millisecondsPerPixel: number;
+};
 ```
 
 ## Mark Line Style
@@ -43,17 +57,54 @@ const ganttOptions = {
     {
       date: '2024-01-01',
       style: {
-        color: 'red',
+        lineColor: 'red',
+        lineWidth: 1,
       },
     },
     {
       date: '2024-01-02',
       style: {
-        color: 'blue',
+        lineColor: 'blue',
+        lineWidth: 2,
       },
     },
   ],
 };
+```
+
+When the mark line width needs to change with timeline zooming, configure `style.lineWidth` as a function. The function is re-executed whenever the mark line refreshes, and its argument includes the current timeline column width, cell width, and milliseconds-per-pixel ratio:
+
+```javascript
+const ganttOptions = {
+  markLine: [
+    {
+      date: '2024-07-17',
+      content: 'Dynamic width',
+      style: {
+        lineWidth: ({ timelineColWidth }) => Math.max(1, Math.round(timelineColWidth / 20)),
+        lineColor: 'blue',
+        lineDash: [8, 4]
+      }
+    }
+  ]
+};
+```
+
+You can also configure the whole `style` as a function:
+
+```javascript
+const ganttOptions = {
+  markLine: [
+    {
+      date: '2024-07-17',
+      style: ({ millisecondsPerPixel }) => ({
+        lineWidth: millisecondsPerPixel > 86400000 ? 1 : 3,
+        lineColor: 'red'
+      })
+    }
+  ]
+};
+```
 
 ## Mark Line Position
 

--- a/docs/assets/guide/zh/gantt/gantt_markline.md
+++ b/docs/assets/guide/zh/gantt/gantt_markline.md
@@ -15,10 +15,10 @@ IMarkLine 配置项如下：
 ```javascript
 export interface IMarkLine {
   date: string;
-  style?: ILineStyle;
+  style?: IMarkLineStyle | ((args: IMarkLineStyleArgumentType) => IMarkLineStyle);
   /** 标记线显示在日期列下的位置 默认为'left' */
   position?: 'left' | 'right' | 'middle' | 'date';
-  /** 自动将日期范围内 包括改标记线 */
+  /** 自动将日期范围内包括该标记线 */
   scrollToMarkLine?: boolean;
   content?: string; // markLine中内容
   /** markLine中内容的样式 */
@@ -31,6 +31,20 @@ export interface IMarkLine {
     cornerRadius?: string;
   }
 }
+
+export type IMarkLineStyle = Omit<ILineStyle, 'lineWidth'> & {
+  lineWidth?: number | ((args: IMarkLineStyleArgumentType) => number);
+};
+
+export type IMarkLineStyleArgumentType = {
+  date: Date;
+  dateIndex: number;
+  dateX: number;
+  cellStartX: number;
+  cellWidth: number;
+  timelineColWidth: number;
+  millisecondsPerPixel: number;
+};
 ```
 
 ## 标记线样式
@@ -43,17 +57,54 @@ const ganttOptions = {
     {
       date: '2024-01-01',
       style: {
-        color: 'red',
+        lineColor: 'red',
+        lineWidth: 1,
       },
     },
     {
       date: '2024-01-02',
       style: {
-        color: 'blue',
+        lineColor: 'blue',
+        lineWidth: 2,
       },
     },
   ],
 };
+```
+
+当标记线宽度需要跟随时间轴缩放变化时，可以将 `style.lineWidth` 配置为函数。函数会在标记线刷新时重新执行，参数中包含当前时间轴列宽、单元格宽度和毫秒/像素比例等信息：
+
+```javascript
+const ganttOptions = {
+  markLine: [
+    {
+      date: '2024-07-17',
+      content: '动态宽度',
+      style: {
+        lineWidth: ({ timelineColWidth }) => Math.max(1, Math.round(timelineColWidth / 20)),
+        lineColor: 'blue',
+        lineDash: [8, 4]
+      }
+    }
+  ]
+};
+```
+
+也可以将整个 `style` 配置为函数：
+
+```javascript
+const ganttOptions = {
+  markLine: [
+    {
+      date: '2024-07-17',
+      style: ({ millisecondsPerPixel }) => ({
+        lineWidth: millisecondsPerPixel > 86400000 ? 1 : 3,
+        lineColor: 'red'
+      })
+    }
+  ]
+};
+```
 
 ## 标记线位置
 

--- a/docs/assets/option/en/common/gantt/mark-line.md
+++ b/docs/assets/option/en/common/gantt/mark-line.md
@@ -5,7 +5,7 @@ IMarkLine specific definition:
 ```
 export interface IMarkLine {
   date: string;
-  style?: ILineStyle;
+  style?: IMarkLineStyle | ((args: IMarkLineStyleArgumentType) => IMarkLineStyle);
   /** The position where the mark line is displayed under the date column. Default is 'left' */
   position?: 'left' | 'right' | 'middle' | 'date';
   /** Automatically include the mark line within the date range */
@@ -21,6 +21,20 @@ export interface IMarkLine {
     cornerRadius?: string;
   }
 }
+
+export type IMarkLineStyle = Omit<ILineStyle, 'lineWidth'> & {
+  lineWidth?: number | ((args: IMarkLineStyleArgumentType) => number);
+};
+
+export type IMarkLineStyleArgumentType = {
+  date: Date;
+  dateIndex: number;
+  dateX: number;
+  cellStartX: number;
+  cellWidth: number;
+  timelineColWidth: number;
+  millisecondsPerPixel: number;
+};
 ```
 
 ${prefix} date(string)
@@ -29,13 +43,46 @@ Specify date
 
 Required
 
-${prefix} style(ILineStyle)
+${prefix} style(IMarkLineStyle | (args: IMarkLineStyleArgumentType) => IMarkLineStyle)
 
 Mark line style
 
 Optional
 
 {{ use: common-gantt-line-style }}
+
+`style` can be configured as a function. The function is re-executed whenever the mark line refreshes, such as after timeline zooming, so the style can be recalculated from the latest timeline size.
+
+`style.lineWidth` also supports a function value, which can be used to dynamically calculate the mark line width based on the current zoom state.
+
+Function arguments:
+
+```
+export type IMarkLineStyleArgumentType = {
+  date: Date; // The mark line date
+  dateIndex: number; // The date cell index where the mark line is located
+  dateX: number; // The mark line x position in the timeline coordinate system
+  cellStartX: number; // The start x position of the date cell containing the mark line
+  cellWidth: number; // The current width of the date cell containing the mark line
+  timelineColWidth: number; // The current timeline column width after zoom or scale changes
+  millisecondsPerPixel: number; // Current milliseconds represented by one pixel
+};
+```
+
+Example:
+
+```javascript
+markLine: [
+  {
+    date: '2024-07-17',
+    style: {
+      lineWidth: ({ timelineColWidth }) => Math.max(1, Math.round(timelineColWidth / 20)),
+      lineColor: 'blue',
+      lineDash: [8, 4]
+    }
+  }
+]
+```
 
 ${prefix} position('left' | 'right' | 'middle' | 'date')
 

--- a/docs/assets/option/zh/common/gantt/mark-line.md
+++ b/docs/assets/option/zh/common/gantt/mark-line.md
@@ -5,10 +5,10 @@ IMarkLine 具体定义：
 ```
 export interface IMarkLine {
   date: string;
-  style?: ILineStyle;
+  style?: IMarkLineStyle | ((args: IMarkLineStyleArgumentType) => IMarkLineStyle);
   /** 标记线显示在日期列下的位置 默认为'left' */
   position?: 'left' | 'right' | 'middle' | 'date';
-  /** 自动将日期范围内 包括改标记线 */
+  /** 自动将日期范围内包括该标记线 */
   scrollToMarkLine?: boolean;
   content?: string; // markLine中内容
   /** markLine中内容的样式 */
@@ -21,6 +21,20 @@ export interface IMarkLine {
     cornerRadius?: string;
   }
 }
+
+export type IMarkLineStyle = Omit<ILineStyle, 'lineWidth'> & {
+  lineWidth?: number | ((args: IMarkLineStyleArgumentType) => number);
+};
+
+export type IMarkLineStyleArgumentType = {
+  date: Date;
+  dateIndex: number;
+  dateX: number;
+  cellStartX: number;
+  cellWidth: number;
+  timelineColWidth: number;
+  millisecondsPerPixel: number;
+};
 ```
 
 ${prefix} date(string)
@@ -29,13 +43,46 @@ ${prefix} date(string)
 
 必填
 
-${prefix} style(ILineStyle)
+${prefix} style(IMarkLineStyle | (args: IMarkLineStyleArgumentType) => IMarkLineStyle)
 
 标记线样式
 
 非必填
 
 {{ use: common-gantt-line-style }}
+
+`style` 支持配置为函数，函数会在标记线刷新时重新执行，例如缩放时间轴后会基于最新时间轴尺寸重新计算样式。
+
+`style.lineWidth` 也支持配置为函数，可用于根据当前缩放状态动态计算标记线宽度。
+
+函数参数说明：
+
+```
+export type IMarkLineStyleArgumentType = {
+  date: Date; // 标记线对应日期
+  dateIndex: number; // 标记线所在日期单元格索引
+  dateX: number; // 标记线在时间轴坐标系中的 x 坐标
+  cellStartX: number; // 标记线所在日期单元格起始 x 坐标
+  cellWidth: number; // 标记线所在日期单元格当前宽度
+  timelineColWidth: number; // 当前缩放或时间刻度下的时间轴列宽
+  millisecondsPerPixel: number; // 当前每像素代表的毫秒数
+};
+```
+
+示例：
+
+```javascript
+markLine: [
+  {
+    date: '2024-07-17',
+    style: {
+      lineWidth: ({ timelineColWidth }) => Math.max(1, Math.round(timelineColWidth / 20)),
+      lineColor: 'blue',
+      lineDash: [8, 4]
+    }
+  }
+]
+```
 
 ${prefix} position('left' | 'right' | 'middle' | 'date')
 

--- a/packages/vtable-gantt/__tests__/gantt-bugserver-init.test.ts
+++ b/packages/vtable-gantt/__tests__/gantt-bugserver-init.test.ts
@@ -7,6 +7,23 @@ import { Gantt } from '../src/index';
 import { defaultPixelRatio } from '../src/tools/pixel-ratio';
 
 describe('bugserver gantt initialization', () => {
+  function findFirstMarkLineShape(gantt) {
+    let result;
+    function walk(node) {
+      if (!node || result) {
+        return;
+      }
+      if (node.type === 'line') {
+        result = node;
+        return;
+      }
+      const children = node.children || node._children;
+      children?.forEach?.(child => walk(child));
+    }
+    walk(gantt.scenegraph.markLine.markLIneContainer);
+    return result;
+  }
+
   test('initializes gantt with mixed date formats and top-level columns', () => {
     const container = createDiv();
     container.style.width = '800px';
@@ -104,6 +121,58 @@ describe('bugserver gantt initialization', () => {
     });
 
     expect(gantt.scenegraph.stage).toBeDefined();
+
+    gantt.release?.();
+    container.remove();
+  });
+
+  test('recomputes markLine function style when refreshed after zoom scale changes', () => {
+    const container = createDiv();
+    container.style.width = '800px';
+    container.style.height = '400px';
+    const calls = [];
+
+    const gantt = new Gantt(container, {
+      records: [
+        { id: 1, title: 'Task 1', start: '2024-07-05', end: '2024-07-10' },
+        { id: 2, title: 'Task 2', start: '2024-07-11', end: '2024-07-15' }
+      ],
+      columns: [{ field: 'title', title: 'title', width: 200 }],
+      taskBar: {
+        startDateField: 'start',
+        endDateField: 'end'
+      },
+      timelineHeader: {
+        colWidth: 30,
+        scales: [
+          { unit: 'week', step: 1, startOfWeek: 'sunday' },
+          { unit: 'day', step: 1 }
+        ]
+      },
+      minDate: '2024-07-01',
+      maxDate: '2024-07-31',
+      markLine: [
+        {
+          date: '2024-07-17',
+          style: {
+            lineColor: 'blue',
+            lineWidth: ({ timelineColWidth }) => {
+              calls.push(timelineColWidth);
+              return timelineColWidth > 60 ? 6 : 2;
+            }
+          }
+        }
+      ]
+    });
+
+    expect(findFirstMarkLineShape(gantt).attribute.lineWidth).toBe(2);
+
+    gantt.parsedOptions.timelineColWidth = 80;
+    gantt.scenegraph.markLine.refresh();
+
+    expect(findFirstMarkLineShape(gantt).attribute.lineWidth).toBe(6);
+    expect(calls).toContain(30);
+    expect(calls).toContain(80);
 
     gantt.release?.();
     container.remove();

--- a/packages/vtable-gantt/examples/gantt/gantt-zoom.ts
+++ b/packages/vtable-gantt/examples/gantt/gantt-zoom.ts
@@ -1172,26 +1172,27 @@ export function createTable() {
     },
     // minDate: '2024-07-01',
     // maxDate: '2024-10-15',
-    // markLine: [
-    //   {
-    //     date: '2024-07-17',
-    //     style: {
-    //       lineWidth: 1,
-    //       lineColor: 'blue',
-    //       lineDash: [8, 4]
-    //     }
-    //   },
-    //   {
-    //     date: '2024-08-17',
-    //     position: 'middle',
-    //     // scrollToMarkLine: true,
-    //     style: {
-    //       lineWidth: 2,
-    //       lineColor: 'red',
-    //       lineDash: [8, 4]
-    //     }
-    //   }
-    // ],
+    markLine: [
+      {
+        date: '2024-07-17',
+        content: '动态宽度',
+        style: {
+          lineWidth: ({ timelineColWidth }) => Math.max(1, Math.round(timelineColWidth / 20)),
+          lineColor: 'blue',
+          lineDash: [8, 4]
+        }
+      },
+      {
+        date: '2024-08-17',
+        content: '固定宽度',
+        position: 'middle',
+        style: {
+          lineWidth: 2,
+          lineColor: 'red',
+          lineDash: [8, 4]
+        }
+      }
+    ],
     rowSeriesNumber: {
       title: '行号',
       dragOrder: true,

--- a/packages/vtable-gantt/src/gantt-helper.ts
+++ b/packages/vtable-gantt/src/gantt-helper.ts
@@ -72,30 +72,38 @@ export function generateMarkLine(markLine?: boolean | IMarkLine | IMarkLine[]): 
     ];
   } else if (Array.isArray(markLine)) {
     return markLine.map((item, index) => {
+      const style = item.style;
       return {
         ...item,
         date: item.date,
         scrollToMarkLine: item.scrollToMarkLine,
         position: item.position ?? 'left',
-        style: {
-          lineColor: item.style?.lineColor || 'red',
-          lineWidth: item.style?.lineWidth || 1,
-          lineDash: item.style?.lineDash
-        }
+        style:
+          typeof style === 'function'
+            ? style
+            : {
+                lineColor: style?.lineColor || 'red',
+                lineWidth: style?.lineWidth ?? 1,
+                lineDash: style?.lineDash
+              }
       };
     });
   }
+  const style = (markLine as IMarkLine).style;
   return [
     {
       ...markLine,
       date: (markLine as IMarkLine).date,
       scrollToMarkLine: (markLine as IMarkLine).scrollToMarkLine ?? true,
       position: (markLine as IMarkLine).position ?? 'left',
-      style: {
-        lineColor: (markLine as IMarkLine).style?.lineColor || 'red',
-        lineWidth: (markLine as IMarkLine).style?.lineWidth || 1,
-        lineDash: (markLine as IMarkLine).style?.lineDash
-      }
+      style:
+        typeof style === 'function'
+          ? style
+          : {
+              lineColor: style?.lineColor || 'red',
+              lineWidth: style?.lineWidth ?? 1,
+              lineDash: style?.lineDash
+            }
     }
   ];
 }

--- a/packages/vtable-gantt/src/scenegraph/mark-line.ts
+++ b/packages/vtable-gantt/src/scenegraph/mark-line.ts
@@ -1,8 +1,17 @@
 import { createDateAtMidnight } from '../tools/util';
-import { DayTimes } from '../gantt-helper';
-//import type { IMarkLine } from '../ts-types';
+import type { ILineStyle, IMarkLine, IMarkLineStyleArgumentType } from '../ts-types';
 import type { Scenegraph } from './scenegraph';
 import { Group, createLine, Text } from '@visactor/vtable/es/vrender';
+
+function resolveMarkLineStyle(line: IMarkLine, args: IMarkLineStyleArgumentType): ILineStyle {
+  const style = typeof line.style === 'function' ? line.style(args) : line.style;
+  const lineWidth = typeof style?.lineWidth === 'function' ? style.lineWidth(args) : style?.lineWidth;
+  return {
+    lineColor: style?.lineColor || 'red',
+    lineWidth: lineWidth ?? 1,
+    lineDash: style?.lineDash
+  };
+}
 
 export class MarkLine {
   _scene: Scenegraph;
@@ -53,7 +62,6 @@ export class MarkLine {
     const minDate = this._scene._gantt.parsedOptions.minDate;
     minDate &&
       markLine.forEach(line => {
-        const style = line.style;
         const contentStyle = line.contentStyle || {};
         const date = this._scene._gantt.parsedOptions.timeScaleIncludeHour
           ? createDateAtMidnight(line.date)
@@ -76,6 +84,15 @@ export class MarkLine {
         } else if (line.position === 'middle') {
           dateX = cellStartX + cellWidth / 2;
         }
+        const style = resolveMarkLineStyle(line, {
+          date,
+          dateIndex: cellIndex,
+          dateX,
+          cellStartX,
+          cellWidth,
+          timelineColWidth: this._scene._gantt.parsedOptions.timelineColWidth,
+          millisecondsPerPixel: this._scene._gantt.getCurrentMillisecondsPerPixel()
+        });
         const markLineGroup = new Group({
           pickable: false,
           x: dateX - this.markLineContainerWidth / 2,

--- a/packages/vtable-gantt/src/ts-types/gantt-engine.ts
+++ b/packages/vtable-gantt/src/ts-types/gantt-engine.ts
@@ -328,6 +328,27 @@ export type ILineStyle = {
   lineWidth?: number;
   lineDash?: number[];
 };
+/** markLine style function arguments, recalculated whenever markLine is refreshed, such as after zoom changes. */
+export type IMarkLineStyleArgumentType = {
+  /** The normalized markLine date. */
+  date: Date;
+  /** The date cell index where the markLine is located. */
+  dateIndex: number;
+  /** The markLine x position in the timeline coordinate system. */
+  dateX: number;
+  /** The start x position of the date cell containing the markLine. */
+  cellStartX: number;
+  /** The current width of the date cell containing the markLine. */
+  cellWidth: number;
+  /** The current timeline column width after zoom or scale changes. */
+  timelineColWidth: number;
+  /** Current milliseconds represented by one pixel. */
+  millisecondsPerPixel: number;
+};
+export type IMarkLineStyle = Omit<ILineStyle, 'lineWidth'> & {
+  lineWidth?: number | ((args: IMarkLineStyleArgumentType) => number);
+};
+export type IMarkLineStyleFunction = (args: IMarkLineStyleArgumentType) => IMarkLineStyle;
 export type IPointStyle = {
   strokeColor?: string;
   strokeWidth?: number;
@@ -345,7 +366,7 @@ export interface IMarkLine {
     backgroundColor?: string;
     cornerRadius?: number | number[];
   };
-  style?: ILineStyle;
+  style?: IMarkLineStyle | IMarkLineStyleFunction;
   /** 标记线显示在日期列下的位置 默认为'left' */
   position?: 'left' | 'right' | 'middle' | 'date';
   /** 自动将日期范围内 包括改标记线 */


### PR DESCRIPTION
## Summary
- Support function-based Gantt markLine styles and dynamic lineWidth recalculation on refresh.
- Add a regression test for zoom-related markLine line width updates.
- Update Gantt zoom demos and markLine docs in both Chinese and English.

## Test plan
- [x] rush test --only tag:package
- [x] Verified gantt-zoom demo on local examples server

🤖 Generated with Claude Code