### PR TITLE
fix(vtable-sheet): exclude test shim from compile

### DIFF
--- a/common/changes/@visactor/vtable-sheet/fix-vtable-sheet-compile_2026-08-25-09-30.json
+++ b/common/changes/@visactor/vtable-sheet/fix-vtable-sheet-compile_2026-08-25-09-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@visactor/vtable-sheet",
+      "comment": "fix: keep test-only plugin sources out of the vtable-sheet package compile",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@visactor/vtable-sheet",
+  "email": "108231307+dajiaohuang@users.noreply.github.com"
+}

--- a/packages/vtable-sheet/src/components/vtable-sheet.ts
+++ b/packages/vtable-sheet/src/components/vtable-sheet.ts
@@ -13,7 +13,7 @@ import type {
   IColumnDefine,
   SheetData
 } from '../ts-types';
-import type { MultiSheetImportResult } from '@visactor/vtable-plugins/src/excel-import/types';
+import type { MultiSheetImportResult } from '@visactor/vtable-plugins';
 import type { TableEventHandlersEventArgumentMap } from '@visactor/vtable/es/ts-types/events';
 import SheetTabDragManager from '../managers/tab-drag-manager';
 import { FormulaAutocomplete } from '../formula/formula-autocomplete';

--- a/packages/vtable-sheet/tsconfig.json
+++ b/packages/vtable-sheet/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "@internal/ts-config/tsconfig.base.json",
   "include": ["src"],
-  "compilerOptions": {    
+  "exclude": ["src/test-shims"],
+  "compilerOptions": {
     "types": ["jest", "offscreencanvas", "node"],
     "lib": ["DOM", "ESNext"],
     "baseUrl": "./",


### PR DESCRIPTION
### 🤔 This is a ...

- [x] Bug fix
- [x] TypeScript definition update

### 🔗 Related issue link

Fixes #5295

### 💡 Background and solution

`vtable-sheet`'s production TypeScript project currently includes `src/test-shims/vtable-plugins.ts`. That test-only shim re-exports the sibling `vtable-plugins` source tree, which is outside `vtable-sheet`'s configured `rootDir`, so `rushx compile` fails with TS6059/TS6307 diagnostics.

This change:

- excludes the test-only shim directory from the production tsconfig; and
- imports `MultiSheetImportResult` from the existing public `@visactor/vtable-plugins` export instead of its source path.

The Jest configuration continues to resolve the shim for package tests.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Keep test-only plugin sources out of the `vtable-sheet` production compile. |
| 🇨🇳 Chinese | 避免 `vtable-sheet` 生产编译包含仅测试使用的插件源码。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Testing

- `node ../../common/scripts/install-run-rushx.js compile` in `packages/vtable-sheet`
- `node ../../common/scripts/install-run-rushx.js test` in `packages/vtable-sheet` (76 suites, 446 tests)
- Repository pre-push hook: `rush test --only tag:package`
- `rush build -t @visactor/vtable-sheet` (completed with the repository's existing warning-tolerant build configuration)