### PR TITLE
fix(vtable): update nested fields by path

### DIFF
--- a/common/changes/@visactor/vtable/fix-issue-4186-nested-field-update_2026-09-04-10-30.json
+++ b/common/changes/@visactor/vtable/fix-issue-4186-nested-field-update_2026-09-04-10-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix: update nested fields by path",
+      "type": "patch",
+      "packageName": "@visactor/vtable"
+    }
+  ],
+  "packageName": "@visactor/vtable",
+  "email": "biukam.w@gmail.com"
+}

--- a/packages/vtable/__tests__/data-update/listTable-nested-field-update.test.ts
+++ b/packages/vtable/__tests__/data-update/listTable-nested-field-update.test.ts
@@ -1,0 +1,80 @@
+// @ts-nocheck
+import { ListTable } from '../../src';
+import { createDiv } from '../dom';
+
+describe('ListTable nested field updates', () => {
+  test('updates a nested field and reports its old and changed values', () => {
+    const field = 'facts.2025-02.qty';
+    const records = [{ facts: { '2025-02': { qty: 10 } } }];
+    const table = new ListTable({
+      container: createDiv(),
+      columns: [{ field, title: 'Quantity' }],
+      records
+    });
+    const events: any[] = [];
+    table.on('change_cell_value', event => events.push(event));
+
+    table.changeCellValueByRecord(0, field, '12', { autoRefresh: false });
+
+    expect(records[0].facts['2025-02'].qty).toBe(12);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      col: 0,
+      row: 1,
+      recordIndex: 0,
+      field,
+      rawValue: 10,
+      currentValue: 10,
+      changedValue: 12
+    });
+    table.release();
+  });
+
+  test('updates nested fields in a batch change and reports the aggregate event', () => {
+    const field = 'facts.2025-02.qty';
+    const records = [{ facts: { '2025-02': { qty: 10 } } }];
+    const table = new ListTable({
+      container: createDiv(),
+      columns: [{ field, title: 'Quantity' }],
+      records
+    });
+    const cellEvents: any[] = [];
+    const batchEvents: any[] = [];
+    table.on('change_cell_value', event => cellEvents.push(event));
+    table.on('change_cell_values', event => batchEvents.push(event));
+
+    table.changeCellValuesByRecords([{ recordIndex: 0, field, value: '12' }], { autoRefresh: false });
+
+    expect(records[0].facts['2025-02'].qty).toBe(12);
+    expect(cellEvents).toHaveLength(1);
+    expect(cellEvents[0].changedValue).toBe(12);
+    expect(batchEvents).toHaveLength(1);
+    expect(batchEvents[0].values).toEqual(cellEvents);
+    table.release();
+  });
+
+  test('updates an array field path and reports its old and changed values', () => {
+    const field = ['facts', '2025-02', 'qty'];
+    const records = [{ facts: { '2025-02': { qty: 10 } } }];
+    const table = new ListTable({
+      container: createDiv(),
+      columns: [{ field, title: 'Quantity' }],
+      records
+    });
+    const events: any[] = [];
+    table.on('change_cell_value', event => events.push(event));
+
+    table.changeCellValueByRecord(0, [...field], '12', { autoRefresh: false });
+
+    expect(records[0].facts['2025-02'].qty).toBe(12);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      col: 0,
+      recordIndex: 0,
+      rawValue: 10,
+      currentValue: 10,
+      changedValue: 12
+    });
+    table.release();
+  });
+});

--- a/packages/vtable/__tests__/data/data-source-nested-field-update.test.ts
+++ b/packages/vtable/__tests__/data/data-source-nested-field-update.test.ts
@@ -1,0 +1,106 @@
+// @ts-nocheck
+import { DataSource, getField, getRecordFieldValue } from '../../src/data/DataSource';
+
+describe('DataSource nested field updates', () => {
+  test('updates a dotted field path by record index', () => {
+    const records = [{ facts: { '2025-02': { qty: 10 } } }];
+    const dataSource = new DataSource({ records });
+
+    dataSource.changeFieldValueByRecordIndex('18', 0, 'facts.2025-02.qty');
+
+    expect(records[0].facts['2025-02'].qty).toBe(18);
+    expect(records[0]['facts.2025-02.qty']).toBeUndefined();
+    dataSource.release();
+  });
+
+  test('updates an array field path by record index', () => {
+    const records = [{ facts: { '2025-02': { qty: 10 } } }];
+    const field = ['facts', '2025-02', 'qty'];
+    const dataSource = new DataSource({ records });
+
+    dataSource.changeFieldValueByRecordIndex('18', 0, field);
+
+    expect(records[0].facts['2025-02'].qty).toBe(18);
+    expect(records[0]['facts,2025-02,qty']).toBeUndefined();
+    dataSource.release();
+  });
+
+  test('updates an array field path through the view-index write path', () => {
+    const records = [{ facts: { '2025-02': { qty: 10 } } }];
+    const field = ['facts', '2025-02', 'qty'];
+    const dataSource = new DataSource({ records });
+
+    dataSource.changeFieldValue('18', 0, field);
+
+    expect(records[0].facts['2025-02'].qty).toBe(18);
+    expect(records[0]['facts,2025-02,qty']).toBeUndefined();
+    dataSource.release();
+  });
+
+  test('keeps array paths distinct from comma-delimited literal keys', () => {
+    const records = [{ facts: { '2025-02': { qty: 10 } }, 'facts,2025-02,qty': 11 }];
+    const field = ['facts', '2025-02', 'qty'];
+    const dataSource = new DataSource({ records });
+    const table = { leftRowSeriesNumberCount: 0 } as any;
+
+    dataSource.changeFieldValueByRecordIndex(18, 0, field);
+
+    expect(records[0].facts['2025-02'].qty).toBe(18);
+    expect(records[0]['facts,2025-02,qty']).toBe(11);
+    expect(getRecordFieldValue(records[0], field)).toBe(18);
+    expect(getField(records[0], field, 0, 0, table, () => undefined)).toBe(18);
+    dataSource.release();
+  });
+
+  test('updates a dotted field path through the view-index write path', () => {
+    const records = [{ facts: { '2025-02': { qty: 10 } } }];
+    const dataSource = new DataSource({ records });
+
+    dataSource.changeFieldValue('18', 0, 'facts.2025-02.qty');
+
+    expect(records[0].facts['2025-02'].qty).toBe(18);
+    expect(records[0]['facts.2025-02.qty']).toBeUndefined();
+    dataSource.release();
+  });
+
+  test('creates missing objects while updating a dotted field path', () => {
+    const records = [{}];
+    const dataSource = new DataSource({ records });
+
+    dataSource.changeFieldValueByRecordIndex(18, 0, 'facts.2025-02.qty');
+
+    expect(records[0]).toEqual({ facts: { '2025-02': { qty: 18 } } });
+    dataSource.release();
+  });
+
+  test('prefers an existing literal dotted field over path traversal', () => {
+    const records = [{ facts: { '2025-02': { qty: 10 } }, 'facts.2025-02.qty': 11 }];
+    const dataSource = new DataSource({ records });
+
+    dataSource.changeFieldValueByRecordIndex(18, 0, 'facts.2025-02.qty');
+
+    expect(records[0]['facts.2025-02.qty']).toBe(18);
+    expect(records[0].facts['2025-02'].qty).toBe(10);
+    dataSource.release();
+  });
+
+  test('does not mutate inherited objects while creating a nested field path', () => {
+    const inherited = { facts: { '2025-02': { qty: 10 } } };
+    const record = Object.create(inherited);
+    const dataSource = new DataSource({ records: [record] });
+
+    dataSource.changeFieldValueByRecordIndex(18, 0, 'facts.2025-02.qty');
+
+    expect(record).toHaveProperty('facts', { '2025-02': { qty: 18 } });
+    expect(inherited.facts['2025-02'].qty).toBe(10);
+    dataSource.release();
+  });
+
+  test('recognizes nested fields in hasField', () => {
+    const records = [{ facts: { '2025-02': { qty: 10 } } }];
+    const dataSource = new DataSource({ records });
+
+    expect(dataSource.hasField(0, 'facts.2025-02.qty')).toBe(true);
+    dataSource.release();
+  });
+});

--- a/packages/vtable/src/ListTable.ts
+++ b/packages/vtable/src/ListTable.ts
@@ -18,7 +18,7 @@ import type {
 } from './ts-types';
 import { HierarchyState } from './ts-types';
 import { SimpleHeaderLayoutMap } from './layout';
-import { isArray, isValid } from '@visactor/vutils';
+import { arrayEqual, isArray, isValid } from '@visactor/vutils';
 import {
   _setDataSource,
   _setRecords,
@@ -49,7 +49,7 @@ import type { IEmptyTipComponent } from './components/empty-tip/empty-tip';
 import { Factory } from './core/factory';
 import { getGroupByDataConfig } from './core/group-helper';
 import { DataSource, type CachedDataSource } from './data';
-import { getValueFromDeepArray } from './data/DataSource';
+import { getRecordFieldValue, getValueFromDeepArray } from './data/DataSource';
 import {
   listTableAddRecord,
   listTableAddRecords,
@@ -98,6 +98,10 @@ function clearLayoutColumnState(columns: ColumnsDefine | undefined) {
     });
     clearLayoutColumnState((column as any).children ?? (column as any).columns);
   });
+}
+
+function isSameField(left: FieldDef, right: FieldDef): boolean {
+  return left === right || (Array.isArray(left) && Array.isArray(right) && arrayEqual(left, right));
 }
 
 // registerAxis();
@@ -703,7 +707,7 @@ export class ListTable extends BaseTable implements ListTableAPI {
     return this.dataSource.getTableIndex(recordIndex) + this.columnHeaderLevelCount;
   }
   getTableIndexByField(field: FieldDef) {
-    const colObj = this.internalProps.layoutMap.columnObjects.find((col: any) => col.field === field);
+    const colObj = this.internalProps.layoutMap.columnObjects.find((col: any) => isSameField(col.field, field));
     if (!colObj) {
       return -1;
     }
@@ -1163,7 +1167,7 @@ export class ListTable extends BaseTable implements ListTableAPI {
    */
   getCellRangeByField(field: FieldDef, index: number): CellRange | null {
     const { layoutMap } = this.internalProps;
-    const colObj = layoutMap.columnObjects.find((col: any) => col.field === field);
+    const colObj = layoutMap.columnObjects.find((col: any) => isSameField(col.field, field));
     if (colObj) {
       const layoutRange = layoutMap.getBodyLayoutRangeById(colObj.id);
       let startRow;
@@ -1938,9 +1942,9 @@ export class ListTable extends BaseTable implements ListTableAPI {
     const records = (this.dataSource as DataSource).dataSourceObj?.records as any[] | undefined;
     let record: any;
     let oldValue: any;
-    if (Array.isArray(records) && (typeof field === 'string' || typeof field === 'number')) {
+    if (Array.isArray(records) && (typeof field === 'string' || typeof field === 'number' || Array.isArray(field))) {
       record = Array.isArray(recordIndex) ? getValueFromDeepArray(records, recordIndex) : records[recordIndex];
-      oldValue = record?.[field as any];
+      oldValue = getRecordFieldValue(record, field);
     }
 
     this.dataSource.changeFieldValueByRecordIndex(value, recordIndex, field, this);
@@ -1950,7 +1954,9 @@ export class ListTable extends BaseTable implements ListTableAPI {
     }
 
     const changedValue =
-      record && (typeof field === 'string' || typeof field === 'number') ? record?.[field as any] : (value as any);
+      record && (typeof field === 'string' || typeof field === 'number' || Array.isArray(field))
+        ? getRecordFieldValue(record, field)
+        : (value as any);
 
     if (oldValue !== changedValue) {
       const cellAddr = this.getCellAddrByFieldRecord(field, recordIndex);
@@ -2028,16 +2034,18 @@ export class ListTable extends BaseTable implements ListTableAPI {
       const records = (this.dataSource as DataSource).dataSourceObj?.records as any[] | undefined;
       let record: any;
       let oldValue: any;
-      if (Array.isArray(records) && (typeof field === 'string' || typeof field === 'number')) {
+      if (Array.isArray(records) && (typeof field === 'string' || typeof field === 'number' || Array.isArray(field))) {
         record = Array.isArray(recordIndex) ? getValueFromDeepArray(records, recordIndex) : records[recordIndex];
-        oldValue = record?.[field as any];
+        oldValue = getRecordFieldValue(record, field);
       }
 
       this.dataSource.changeFieldValueByRecordIndex(value, recordIndex, field, this);
 
       if (triggerEvent) {
         const changedValue =
-          record && (typeof field === 'string' || typeof field === 'number') ? record?.[field as any] : (value as any);
+          record && (typeof field === 'string' || typeof field === 'number' || Array.isArray(field))
+            ? getRecordFieldValue(record, field)
+            : (value as any);
         if (oldValue !== changedValue) {
           const changeValue = {
             col: (this.getCellAddrByFieldRecord(field, recordIndex)?.col ?? -1) as number,

--- a/packages/vtable/src/data/DataSource.ts
+++ b/packages/vtable/src/data/DataSource.ts
@@ -100,6 +100,10 @@ export function getField(
     const colIndex = col - table.leftRowSeriesNumberCount;
     return record[colIndex];
   }
+  if (Array.isArray(fieldGet)) {
+    const fieldResult = getValueByPath(record, [...fieldGet]);
+    return getValue(fieldResult, promiseCallBack);
+  }
   if (isObject(record) && fieldGet in (record as any)) {
     const fieldResult = (record as any)[fieldGet];
 
@@ -107,10 +111,6 @@ export function getField(
   }
   if (typeof fieldGet === 'function') {
     const fieldResult = fieldGet(record, col, row, table);
-    return getValue(fieldResult, promiseCallBack);
-  }
-  if (Array.isArray(fieldGet)) {
-    const fieldResult = getValueByPath(record, [...fieldGet]);
     return getValue(fieldResult, promiseCallBack);
   }
   const fieldArray = `${fieldGet}`.split('.');
@@ -124,6 +124,90 @@ export function getField(
     ...fieldArray
   );
   return getValue(fieldResult, promiseCallBack);
+}
+
+function getRecordFieldPath(field: FieldDef | number): string[] | undefined {
+  if (Array.isArray(field)) {
+    return field;
+  }
+  if (typeof field === 'string' && field.includes('.')) {
+    return field.split('.');
+  }
+  return undefined;
+}
+
+function hasRecordField(record: any, field: FieldDef | number): boolean {
+  if (!isObject(record)) {
+    return false;
+  }
+  const path = getRecordFieldPath(field);
+  if (!Array.isArray(field) && (field as any) in record) {
+    return true;
+  }
+  if (!path) {
+    return false;
+  }
+  let target = record;
+  for (const key of path) {
+    if (!isObject(target) || !(key in target)) {
+      return false;
+    }
+    target = target[key];
+  }
+  return true;
+}
+
+export function getRecordFieldValue(record: any, field: FieldDef | number): any {
+  if (record === null || record === undefined) {
+    return undefined;
+  }
+  const path = getRecordFieldPath(field);
+  if (!Array.isArray(field) && isObject(record) && (field as any) in record) {
+    return record[field as any];
+  }
+  if (!path) {
+    return record[field as any];
+  }
+  return path.reduce((current, key) => {
+    return current === null || current === undefined ? undefined : current[key];
+  }, record);
+}
+
+function setRecordProperty(record: any, key: string, value: any): void {
+  if (key === '__proto__') {
+    Object.defineProperty(record, key, {
+      configurable: true,
+      enumerable: true,
+      value,
+      writable: true
+    });
+    return;
+  }
+  record[key] = value;
+}
+
+export function setRecordFieldValue(record: any, field: FieldDef | number, value: FieldData): void {
+  if (record === null || record === undefined) {
+    return;
+  }
+  const path = getRecordFieldPath(field);
+  if (!path || (!Array.isArray(field) && isObject(record) && (field as any) in record)) {
+    record[field as any] = value;
+    return;
+  }
+
+  if (path.length === 0) {
+    return;
+  }
+  let target = record;
+  for (let i = 0; i < path.length - 1; i++) {
+    const key = path[i];
+    if (!Object.prototype.hasOwnProperty.call(target, key) || target[key] === null || typeof target[key] !== 'object') {
+      setRecordProperty(target, key, {});
+    }
+    target = target[key];
+  }
+  setRecordProperty(target, path[path.length - 1], value);
 }
 
 function _getIndex(sortedIndexMap: null | (number | number[])[], index: number): number | number[] {
@@ -744,8 +828,8 @@ export class DataSource extends EventTarget implements DataSourceAPI {
       if (field === undefined || field === '') {
         field = col - table.leftRowSeriesNumberCount;
       }
-      if (typeof field === 'string' || typeof field === 'number') {
-        const beforeChangedValue = this.beforeChangedRecordsMap.get(dataIndex.toString())?.[field as any]; // this.getOriginalField(index, field, col, row, table);
+      if (typeof field === 'string' || typeof field === 'number' || Array.isArray(field)) {
+        const beforeChangedValue = getRecordFieldValue(this.beforeChangedRecordsMap.get(dataIndex.toString()), field);
         const record = this.getOriginalRecord(dataIndex);
         let formatValue = value;
         if (typeof beforeChangedValue === 'number' && isAllDigits(value)) {
@@ -754,7 +838,7 @@ export class DataSource extends EventTarget implements DataSourceAPI {
         if (isPromise(record)) {
           return record
             .then(record => {
-              record[field as string | number] = formatValue;
+              setRecordFieldValue(record, field, formatValue);
               return formatValue;
             })
             .catch((err: Error) => {
@@ -763,10 +847,10 @@ export class DataSource extends EventTarget implements DataSourceAPI {
             });
         }
         if (record) {
-          record[field] = formatValue;
+          setRecordFieldValue(record, field, formatValue);
         } else {
           this.records[dataIndex as number] = this.addRecordRule === 'Array' ? [] : {};
-          this.records[dataIndex as number][field] = formatValue;
+          setRecordFieldValue(this.records[dataIndex as number], field, formatValue);
         }
       }
     }
@@ -802,8 +886,8 @@ export class DataSource extends EventTarget implements DataSourceAPI {
       );
     }
 
-    if (typeof field === 'string' || typeof field === 'number') {
-      const beforeChangedValue = this.beforeChangedRecordsMap.get(rawKey)?.[field as any];
+    if (typeof field === 'string' || typeof field === 'number' || Array.isArray(field)) {
+      const beforeChangedValue = getRecordFieldValue(this.beforeChangedRecordsMap.get(rawKey), field);
       const rawRecords = Array.isArray((this.dataSourceObj as any)?.records)
         ? (this.dataSourceObj as any).records
         : null;
@@ -817,10 +901,10 @@ export class DataSource extends EventTarget implements DataSourceAPI {
         formatValue = parseFloat(value);
       }
       if (record) {
-        record[field] = formatValue;
+        setRecordFieldValue(record, field, formatValue);
       } else if (rawRecords && typeof recordIndex === 'number') {
         rawRecords[recordIndex] = this.addRecordRule === 'Array' ? [] : {};
-        rawRecords[recordIndex][field] = formatValue;
+        setRecordFieldValue(rawRecords[recordIndex], field, formatValue);
       }
     }
   }
@@ -1651,7 +1735,7 @@ export class DataSource extends EventTarget implements DataSourceAPI {
       return true;
     }
     const record = this.getOriginalRecord(index);
-    return Boolean(record && (field as any) in (record as any));
+    return hasRecordField(record, field);
   }
 
   protected fieldPromiseCallBack(


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
-->

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Release
- [ ] Other (about what?)

### 🔗 Related issue link

fixes #4186

### 💡 Background and solution

`changeFieldValue` and `changeFieldValueByRecordIndex` treated nested `FieldDef` values as literal keys. For a field such as `facts.2025-02.qty`, the update therefore wrote `record["facts.2025-02.qty"]` instead of updating the nested quantity. The corresponding `ListTable` change events also read direct keys, so their old and changed values could be incorrect.

This change adds shared nested-field read and write handling for dotted paths and `string[]` paths. It preserves existing literal dotted-key precedence, creates missing intermediate objects, keeps numeric-string conversion behavior, and uses the same path resolution for `hasField`, column lookup, and change-event values.

Regression tests cover dotted and array paths, missing intermediate objects, literal-key precedence, and single/batch change-event payloads.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix updates for nested fields represented by dotted or array paths, including accurate change-event values. |
| 🇨🇳 Chinese | 修复通过点号路径或数组路径更新嵌套字段，并确保变更事件中的新旧值准确。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### ✅ Verification

- Focused regression tests: 2 suites, 12 tests passed, covering dotted and array paths plus single/batch event payloads.
- Full `@visactor/vtable` Jest suite: 75 suites, 326 tests passed.

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
